### PR TITLE
Make project clang complient.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,21 @@ ROS Based multi robot environment for testing autonomous navigation algorithms
 This is a fork of aau-ros/aau_multi_robot project (see: https://github.com/aau-ros/aau_multi_robot).
 
 ### Installation
-Install ROS:
-1) Install ROS itself: http://wiki.ros.org/ROS/Installation
-2) Initialize catkin: http://wiki.ros.org/ROS/Tutorials/InstallingandConfiguringROSEnvironment
+If you are using Ubuntu-based linux, then you can simply run
+
+```
+wget -O /tmp/ros_multi_robot_ready.sh https://raw.githubusercontent.com/OSLL/multibot/master/scripts/ros_multi_robot_ready.sh; . /tmp/ros_multi_robot_ready.sh
+```
+
+Otherwise, you can follow manual installation:
+
+1. Install ROS itself: http://wiki.ros.org/ROS/Installation
+2. Initialize catkin: http://wiki.ros.org/ROS/Tutorials/InstallingandConfiguringROSEnvironment
 
 Install additional packages:
-1) slam-gmapping: command for ubuntu `sudo apt-get install ros-jade-slam-gmapping`
-3) navigation: command for ubuntu `sudo apt-get install ros-jade-navigation`
-2) mrpt-navigation(not shure in this one): command for ubuntu `sudo apt-get install ros-jade-mrpt-navigation`
-4) teleop_twist_keyboard: clone sources to `catkin_ws/src` using `git clone https://github.com/LeoSko/teleop_twist_keyboard.git` command
+
+1. slam-gmapping: command for ubuntu `sudo apt-get install ros-jade-slam-gmapping`
+2. navigation: command for ubuntu `sudo apt-get install ros-jade-navigation`
+3. teleop_twist_keyboard: clone sources to `catkin_ws/src` using `git clone https://github.com/LeoSko/teleop_twist_keyboard.git` command
 
 These packages should be enough to run `map_merger/launch/test_one.launch`

--- a/README.md
+++ b/README.md
@@ -6,3 +6,15 @@ ROS Based multi robot environment for testing autonomous navigation algorithms
 
 This is a fork of aau-ros/aau_multi_robot project (see: https://github.com/aau-ros/aau_multi_robot).
 
+### Installation
+Install ROS:
+1) Install ROS itself: http://wiki.ros.org/ROS/Installation
+2) Initialize catkin: http://wiki.ros.org/ROS/Tutorials/InstallingandConfiguringROSEnvironment
+
+Install additional packages:
+1) slam-gmapping: command for ubuntu `sudo apt-get install ros-jade-slam-gmapping`
+3) navigation: command for ubuntu `sudo apt-get install ros-jade-navigation`
+2) mrpt-navigation(not shure in this one): command for ubuntu `sudo apt-get install ros-jade-mrpt-navigation`
+4) teleop_twist_keyboard: clone sources to `catkin_ws/src` using `git clone https://github.com/LeoSko/teleop_twist_keyboard.git` command
+
+These packages should be enough to run `map_merger/launch/test_one.launch`

--- a/adhoc_communication/CMakeLists.txt
+++ b/adhoc_communication/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" )
+if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  # ros-jade-navigation contains funtion that, despite its declaration,
+  # doesn't return anything. Clang will warn us about this which, due to
+  # -Werror flag, will ruin compilation.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+endif()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 project(adhoc_communication)
 

--- a/adhoc_communication/src/Logging.h
+++ b/adhoc_communication/src/Logging.h
@@ -99,7 +99,7 @@ uint32_t Logging::running_multicast_threads = 0;
 uint32_t Logging::running_unicast_transport_threads = 0;
 uint32_t Logging::running_unicast_link_threads = 0;
 
-unicast frames sent 
+unicast frames sent
 uint32_t Logging::num_unique_data_frames_sent = 0;
 uint32_t Logging::num_unique_data_frames_forwarded = 0;
 uint32_t Logging::num_data_frames_resent = 0;
@@ -115,7 +115,7 @@ uint32_t Logging::num_relay_detection_sent = 0;
 uint32_t Logging::num_total_frames_sent = 0;
 
 
-/* unicast received sent 
+// unicast received sent
 uint32_t Logging::num_unique_data_frames_received_directly = 0;
 uint32_t Logging::num_unique_data_frames_received_relay = 0;
 uint32_t Logging::num_data_frames_received_directly = 0;
@@ -133,7 +133,7 @@ uint32_t Logging::num_total_frames_received = 0;
 uint32_t Logging::num_total_bytes_sent = 0;
 uint32_t Logging::num_total_bytes_received = 0;
 
-/* mc frames sent 
+// mc frames sent
 uint32_t Logging::num_mc_unique_data_frames_sent = 0;
 uint32_t Logging::num_mc_unique_data_frames_forwarded = 0;
 uint32_t Logging::num_mc_data_frames_resent = 0;
@@ -148,7 +148,7 @@ uint32_t Logging::num_mc_relay_selection_sent = 0;
 uint32_t Logging::num_mc_total_frames_sent = 0;
 
 
-/* mc frames sent 
+// mc frames sent
 uint32_t Logging::num_mc_unique_data_frames_received_directly = 0;
 uint32_t Logging::num_mc_unique_data_frames_received_relay = 0;
 uint32_t Logging::num_mc_data_frames_received_directly = 0;

--- a/adhoc_communication/src/McHandler.cpp
+++ b/adhoc_communication/src/McHandler.cpp
@@ -84,23 +84,20 @@ std::vector<McTree*> McHandler::lostConnectionUplinks(unsigned char* mac_a)
             affected_trees.push_back(tree);
         }
     }
-
-
     return affected_trees;
-
 }
 
 bool McHandler::removeGroup(std::string* group_name)
 {
     McTree* t = getMcGroup(group_name);
-    if (t == NULL)
+    if (t == nullptr)
+    {
         return false;
-    
+    }
     ROS_ERROR("remove %s",group_name->c_str());
-
     groups_->remove(t);
     delete t;
-
+    return true;
 }
 
 
@@ -256,4 +253,4 @@ void McHandler::printMcGroups()
         ROS_ERROR("NAME:[%s] ACTIVE[%u] ENTRIES: UP[%zu] DOWN[%zu] WAITING[%zu] DOWNLINKS[%zu]", tree->group_name_.c_str(), tree->activated, tree->routing_entries_l_.size(), tree->routing_entries_downlinks_l_.size(), tree->waiting_requests_l_.size(), tree->downlinks_l_.size());
     }
 }
-#endif 
+#endif

--- a/adhoc_communication/src/adhoc_communication.cpp
+++ b/adhoc_communication/src/adhoc_communication.cpp
@@ -55,30 +55,37 @@ bool getGroupStateF(adhoc_communication::GetGroupState::Request &req, adhoc_comm
     boost::unique_lock<boost::mutex> lock(mtx_mc_groups);
     McTree *t = mc_handler.getMcGroup(&req.group_name);
 
-    if (t != NULL)
+    if (t != nullptr)
     {
         res.activated = t->activated;
         res.connected = t->connected;
         res.root = t->root;
         res.member = t->member;
 
-        for (std::list<mac*>::iterator it = t->downlinks_l_.begin(); it != t->downlinks_l_.end(); ++it)
+        for (auto it = t->downlinks_l_.begin(); it != t->downlinks_l_.end(); ++it)
         {
             mac* m = *it;
             res.downlinks.push_back(getHostnameFromMac(m->mac_adr));
         }
 
         if (!t->root)
-            res.route_uplink = "Next hop:" + getHostnameFromMac(t->route_uplink_->next_hop) + " RD:" + getIntAsString(t->route_uplink_->root_distance) + " HOBS:" + getIntAsString(t->route_uplink_->hobs) + " CH:" + getIntAsString(t->route_uplink_-> current_hop);
-
+        {
+            res.route_uplink = "Next hop:" + getHostnameFromMac(t->route_uplink_->next_hop)
+                + " RD:" + getIntAsString(t->route_uplink_->root_distance)
+                + " HOBS:" + getIntAsString(t->route_uplink_->hobs)
+                + " CH:" + getIntAsString(t->route_uplink_-> current_hop);
+        }
         else
+        {
             res.route_uplink = "";
+        }
 
         return true;
     }
     else
     {
         res.route_uplink = "No mc entry found!";
+        return false;
     }
 }
 

--- a/adhoc_communication/src/functions.h
+++ b/adhoc_communication/src/functions.h
@@ -151,19 +151,17 @@ std::string getSerializedMessage(t message)
     return serializedMap;
 }
 
-
+/* Description:
+ * returns a C-String that displayed the mac in hex.
+ */
 /*
 const char* getMacAsCStr(unsigned char* mac)
 {
-
-    /* Description:
-     * returns a C-String that displayed the mac in hex.
-     */
-/*
     boost::format fmt("%02X-%02X-%02X-%02X-%02X-%02X");
     for (int i = 0; i != 6; ++i)
+    {
         fmt % static_cast<unsigned int> (mac[i]);
-
+    }
     return fmt.str().c_str();
 }*/
 

--- a/adhoc_communication/src/header.h
+++ b/adhoc_communication/src/header.h
@@ -795,43 +795,44 @@ bool isReachable(unsigned char mac[6])
         PositionSubscriber other_robot;
         other_robot.robot_name_ = getHostnameFromMac(mac);
 
-        for (std::list<PositionSubscriber*>::iterator it = robot_positions_l.begin(); it != robot_positions_l.end(); ++it)
+        for (auto it = robot_positions_l.begin(); it != robot_positions_l.end(); ++it)
         {
             if (other_robot.robot_name_.compare((*it)->robot_name_) == 0)
             {
                 double d = my_sim_position->calcDistance(*it);
 
-                //ROS_ERROR("d: %f",d);
                 if (d == -1)
                 {
-
                     return false;
                 }
 
                 double p_rx = p_tx - (l_0_model + 10 * n_model * log10(d));
 
-
                 if (p_thres <= p_rx)
                 {
                     //ROS_DEBUG("connected with %s %f %f",other_robot->robot_name_.c_str(),d,p_rx);
                     return true;
-                } else
+                }
+                else
+                {
                     return false;
-
+                }
             }
         }
-
-    } else if (sim_robot_macs.compare("") != 0)
+        return false;
+    }
+    else if (sim_robot_macs.compare("") != 0)
     {
         boost::unique_lock<boost::mutex> lock(mtx_neighbors);
         hostname_mac n(mac);
-
-        std::list<hostname_mac>::iterator searchNeighbor = std::find(neighbors_l.begin(), neighbors_l.end(), n);
+        auto searchNeighbor = std::find(neighbors_l.begin(), neighbors_l.end(), n);
 
         return searchNeighbor != neighbors_l.end();
-
-    } else
+    }
+    else
+    {
         return true;
+    }
 }
 
 bool connectedWith(unsigned char mac[6])
@@ -1166,7 +1167,7 @@ void joinAllMcGroups()
            ROS_ERROR("FATAL: %s", g_name.c_str());
        else if(!mc_t->activated)
             ROS_ERROR("NOT CONNECTED: %s", g_name.c_str());
-      /*
+
        uint8_t joinAttemps = 0;
        while ((t.group_name.compare("") == 0 || !t.member) && joinAttemps++ < 10) {
            req.action = true;

--- a/explorer/CMakeLists.txt
+++ b/explorer/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" )
+if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  # ros-jade-navigation contains funtion that, despite its declaration,
+  # doesn't return anything. Clang will warn us about this which, due to
+  # -Werror flag, will ruin compilation.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+endif()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 project(explorer)
 

--- a/explorer/src/ExplorationPlanner.cpp
+++ b/explorer/src/ExplorationPlanner.cpp
@@ -43,46 +43,46 @@
 using namespace explorationPlanner;
 
 template <typename T>
-  std::string NumberToString ( T Number )
-  {
-     std::ostringstream ss;
-     ss << Number;
-     return ss.str();
-  }
+std::string NumberToString ( T Number )
+{
+    std::ostringstream ss;
+    ss << Number;
+    return ss.str();
+}
 
 ExplorationPlanner::ExplorationPlanner(int robot_id, bool robot_prefix_empty, std::string robot_name_parameter, std::string mc_group):
-		costmap_ros_(0), occupancy_grid_array_(0), exploration_trans_array_(0), obstacle_trans_array_(
-				0), frontier_map_array_(0), is_goal_array_(0), map_width_(0), map_height_(
-				0), num_map_cells_(0), initialized_(false), last_mode_(
-				FRONTIER_EXPLORE), p_alpha_(0), p_dist_for_goal_reached_(1), p_goal_angle_penalty_(
-				0), p_min_frontier_size_(0), p_min_obstacle_dist_(0), p_plan_in_unknown_(
-				true), p_same_frontier_dist_(0), p_use_inflated_obs_(false), previous_goal_(
-				0), inflated(0), lethal(0), free(0), threshold_free(127) 
-				, threshold_inflated(252), threshold_lethal(253),frontier_id_count(0), 
-                                exploration_travel_path_global(0), cluster_id(0), initialized_planner(false), 
-                                auction_is_running(false), auction_start(false), auction_finished(true), 
-                                start_thr_auction(false), auction_id_number(1), next_auction_position_x(0), 
+        costmap_ros_(0), occupancy_grid_array_(0), exploration_trans_array_(0), obstacle_trans_array_(
+                0), frontier_map_array_(0), is_goal_array_(0), map_width_(0), map_height_(
+                0), num_map_cells_(0), initialized_(false), last_mode_(
+                FRONTIER_EXPLORE), p_alpha_(0), p_dist_for_goal_reached_(1), p_goal_angle_penalty_(
+                0), p_min_frontier_size_(0), p_min_obstacle_dist_(0), p_plan_in_unknown_(
+                true), p_same_frontier_dist_(0), p_use_inflated_obs_(false), previous_goal_(
+                0), inflated(0), lethal(0), free(0), threshold_free(127)
+                , threshold_inflated(252), threshold_lethal(253),frontier_id_count(0),
+                                exploration_travel_path_global(0), cluster_id(0), initialized_planner(false),
+                                auction_is_running(false), auction_start(false), auction_finished(true),
+                                start_thr_auction(false), auction_id_number(1), next_auction_position_x(0),
                                 next_auction_position_y(0), other_robots_position_x(0), other_robots_position_y(0),
                                 number_of_completed_auctions(0), number_of_uncompleted_auctions(0), first_run(true),
                                 first_negotiation_run(true), robot_prefix_empty_param(false){
-    
-    
+
+
     trajectory_strategy = "euclidean";
     robot_prefix_empty_param = robot_prefix_empty;
-	this->mc_group = mc_group;
-            
+    this->mc_group = mc_group;
+
     responded_t init_responded;
     init_responded.auction_number = 0;
     init_responded.robot_number = 0;
     robots_already_responded.push_back(init_responded);
-    
+
     auction_running = false;
     std::stringstream robot_number;
     robot_number << robot_id;
-    
+
     std::string prefix = "/robot_";
-    std::string robo_name = prefix.append(robot_number.str());   
-    
+    std::string robo_name = prefix.append(robot_number.str());
+
     if(robot_prefix_empty_param == true)
     {
         /*NO SIMULATION*/
@@ -91,33 +91,33 @@ ExplorationPlanner::ExplorationPlanner(int robot_id, bool robot_prefix_empty, st
     }
     std::string sendFrontier_msgs = robo_name +"/adhoc_communication/send_frontier";
     std::string sendAuction_msgs  = robo_name +"/adhoc_communication/send_auction";
-    
+
     ros::NodeHandle tmp;
     nh_service = &tmp;
-    
+
     ROS_DEBUG("Sending frontier: '%s'     SendAuction: '%s'", sendFrontier_msgs.c_str(), sendAuction_msgs.c_str());
-    
+
     ssendFrontier = nh_service->serviceClient<adhoc_communication::SendExpFrontier>(sendFrontier_msgs);
     ssendAuction = nh_service->serviceClient<adhoc_communication::SendExpAuction>(sendAuction_msgs);
 
-    
+
 //    pub_negotion_first = nh_negotiation_first.advertise <adhoc_communication::Frontier> ("negotiation_list_first", 10000);
-    
+
 //    pub_frontiers = nh_frontier.advertise <adhoc_communication::Frontier> ("frontiers", 10000);
 //    pub_visited_frontiers = nh_visited_frontier.advertise <adhoc_communication::Frontier> ("visited_frontiers", 10000);
-    
+
     pub_visited_frontiers_points = nh_visited_Point.advertise <visualization_msgs::MarkerArray> ("visitedfrontierPoints", 2000, true);
-    
+
     pub_Point = nh_Point.advertise < geometry_msgs::PointStamped> ("goalPoint", 100, true);
     pub_frontiers_points = nh_frontiers_points.advertise <visualization_msgs::MarkerArray> ("frontierPoints", 2000, true);
 
 //    pub_auctioning_status = nh_auction_status.advertise<adhoc_communication::AuctionStatus> ("auctionStatus", 1000);
 //    pub_auctioning_first = nh_auction_first.advertise<adhoc_communication::Auction> ("auction_first", 1000);
-    
+
     //pub_clusters = nh_cluster.advertise<geometry_msgs::PolygonStamped>("clusters", 2000, true);
-    
-    
-    
+
+
+
     pub_cluster_grid_0 = nh_cluster_grid.advertise<nav_msgs::GridCells>("cluster_grid_0", 2000, true);
     pub_cluster_grid_1 = nh_cluster_grid.advertise<nav_msgs::GridCells>("cluster_grid_1", 2000, true);
     pub_cluster_grid_2 = nh_cluster_grid.advertise<nav_msgs::GridCells>("cluster_grid_2", 2000, true);
@@ -139,42 +139,42 @@ ExplorationPlanner::ExplorationPlanner(int robot_id, bool robot_prefix_empty, st
     pub_cluster_grid_18 = nh_cluster_grid.advertise<nav_msgs::GridCells>("cluster_grid_18", 2000, true);
     pub_cluster_grid_19 = nh_cluster_grid.advertise<nav_msgs::GridCells>("cluster_grid_19", 2000, true);
 
-    
-    
-        
+
+
+
 //    std::string frontier_sub = robo_name+"/frontiers";
 //    std::string visited_frontiers_sub = robo_name+"/visited_frontiers";
 //    std::string auction_sub = robo_name+"/auction";
 //    std::string all_positions_sub = robo_name+"/all_positions";
 //    ROS_INFO("Subscribing to: ");
 //    ROS_INFO("%s  %s  %s  %s", frontier_sub.c_str(), visited_frontiers_sub.c_str(), auction_sub.c_str(), all_positions_sub.c_str());
-    
-  
+
+
 //    sub_control = nh_control.subscribe("/control", 10000, &ExplorationPlanner::controlCallback, this);
     sub_frontiers = nh_frontier.subscribe(robo_name+"/frontiers", 10000, &ExplorationPlanner::frontierCallback, this);
     sub_visited_frontiers = nh_visited_frontier.subscribe(robo_name+"/visited_frontiers", 10000, &ExplorationPlanner::visited_frontierCallback, this);
-    sub_negotioation = nh_negotiation.subscribe(robo_name+"/negotiation_list", 10000, &ExplorationPlanner::negotiationCallback, this); 
-    sub_auctioning = nh_auction.subscribe(robo_name+"/auction", 1000, &ExplorationPlanner::auctionCallback, this); 
+    sub_negotioation = nh_negotiation.subscribe(robo_name+"/negotiation_list", 10000, &ExplorationPlanner::negotiationCallback, this);
+    sub_auctioning = nh_auction.subscribe(robo_name+"/auction", 1000, &ExplorationPlanner::auctionCallback, this);
     sub_position = nh_position.subscribe(robo_name+"/all_positions", 1000, &ExplorationPlanner::positionCallback, this);
-   
+
     // TODO
 //    sub_robot = nh_robot.subscribe(robo_name+"/adhoc_communication/new_robot", 1000, &ExplorationPlanner::new_robot_callback, this);
-    
-    
+
+
 //    adhoc_communication::Auction auction_init_status_msg;
-//    auction_init_status_msg.start_auction = false; 
+//    auction_init_status_msg.start_auction = false;
 //    auction_init_status_msg.auction_finished = true;
 //    auction_init_status_msg.auction_status_message = true;
 //    sendToMulticast("mc_", auction_init_status_msg, "auction");
-//    
+//
 //    adhoc_communication::Auction auction_init_msg;
-//    auction_init_msg.start_auction = false; 
+//    auction_init_msg.start_auction = false;
 //    auction_init_msg.auction_finished = true;
 //    auction_init_msg.auction_status_message = false;
 //    sendToMulticast("mc_", auction_init_msg, "auction");
-    
-    
-    
+
+
+
 //    if(robot_id == 1)
 //    {
 //        sub_frontiers = nh_frontier.subscribe("/robot_1/frontiers", 10000, &ExplorationPlanner::frontierCallback, this);
@@ -192,7 +192,7 @@ ExplorationPlanner::ExplorationPlanner(int robot_id, bool robot_prefix_empty, st
 //        sub_position = nh_position.subscribe("/robot_0/all_positions", 1000, &ExplorationPlanner::positionCallback, this);
 //        sub_auctioning_status = nh_auction_status.subscribe("/robot_1/auctionStatus", 1000, &ExplorationPlanner::auctionStatusCallback, this);
 //    }
-            
+
     srand((unsigned)time(0));
 }
 
@@ -202,22 +202,22 @@ void ExplorationPlanner::Callbacks()
     while(ros::ok())
     {
 //        publish_subscribe_mutex.lock();
-      
+
         if(robot_name == 1)
         {
                 sub_frontiers = nh_frontier.subscribe("/robot_0/frontiers", 10000, &ExplorationPlanner::frontierCallback, this);
                 sub_visited_frontiers = nh_visited_frontier.subscribe("/robot_0/visited_frontiers", 10000, &ExplorationPlanner::visited_frontierCallback, this);
                 sub_negotioation = nh_negotiation.subscribe("/robot_0/negotiation_list", 10000, &ExplorationPlanner::negotiationCallback, this);
                 sub_auctioning = nh_auction.subscribe("/robot_1/auction", 1000, &ExplorationPlanner::auctionCallback, this);
-                
+
 //                sub_frontiers = nh_frontier.subscribe("/robot_2/frontiers", 10000, &ExplorationPlanner::frontierCallback, this);
 //                sub_visited_frontiers = nh_visited_frontier.subscribe("/robot_2/visited_frontiers", 10000, &ExplorationPlanner::visited_frontierCallback, this);
 //                sub_negotioation = nh_negotiation.subscribe("/robot_2/negotiation_list", 10000, &ExplorationPlanner::negotiationCallback, this);
-//        
+//
 //                sub_frontiers = nh_frontier.subscribe("/robot_3/frontiers", 10000, &ExplorationPlanner::frontierCallback, this);
 //                sub_visited_frontiers = nh_visited_frontier.subscribe("/robot_3/visited_frontiers", 10000, &ExplorationPlanner::visited_frontierCallback, this);
 //                sub_negotioation = nh_negotiation.subscribe("/robot_3/negotiation_list", 10000, &ExplorationPlanner::negotiationCallback, this);
-        
+
         }
         else if(robot_name == 0)
         {
@@ -228,16 +228,16 @@ void ExplorationPlanner::Callbacks()
 //                sub_frontiers = nh_frontier.subscribe("/robot_2/frontiers", 10000, &ExplorationPlanner::frontierCallback, this);
 //                sub_visited_frontiers = nh_visited_frontier.subscribe("/robot_2/visited_frontiers", 10000, &ExplorationPlanner::visited_frontierCallback, this);
 //                sub_negotioation = nh_negotiation.subscribe("/robot_2/negotiation_list", 10000, &ExplorationPlanner::negotiationCallback, this);
-//                
+//
 //                sub_frontiers = nh_frontier.subscribe("/robot_3/frontiers", 10000, &ExplorationPlanner::frontierCallback, this);
 //                sub_visited_frontiers = nh_visited_frontier.subscribe("/robot_3/visited_frontiers", 10000, &ExplorationPlanner::visited_frontierCallback, this);
 //                sub_negotioation = nh_negotiation.subscribe("/robot_3/negotiation_list", 10000, &ExplorationPlanner::negotiationCallback, this);
-                
+
         }
 //        publish_subscribe_mutex.unlock();
-        
+
         r.sleep();
-//        ros::spinOnce();     
+//        ros::spinOnce();
     }
 }
 
@@ -247,7 +247,7 @@ void ExplorationPlanner::Callbacks()
 //    for(int i = 0; i < new_robots->size(); i++)
 //    {
 //        if(new_robots->at(i) == newRobotName)
-//        {          
+//        {
 //            return;
 //        }
 //    }
@@ -256,168 +256,169 @@ void ExplorationPlanner::Callbacks()
 //}
 
 void ExplorationPlanner::initialize_planner(std::string name,
-		costmap_2d::Costmap2DROS *costmap, costmap_2d::Costmap2DROS *costmap_global) {
-	
+        costmap_2d::Costmap2DROS *costmap, costmap_2d::Costmap2DROS *costmap_global) {
+
         ROS_INFO("Initializing the planner");
 
-	//copy the pointed costmap to be available in ExplorationPlanner
-        
-	this->costmap_ros_ = costmap;
+    //copy the pointed costmap to be available in ExplorationPlanner
+
+    this->costmap_ros_ = costmap;
         this->costmap_global_ros_ = costmap_global;
-        
+
         if(initialized_planner == false)
         {
                 nav.initialize("navigation_path", costmap_global_ros_);
                 initialized_planner = true;
         }
-	//Occupancy_grid_array is updated here
-	this->setupMapData();
+    //Occupancy_grid_array is updated here
+    this->setupMapData();
 
-	last_mode_ = FRONTIER_EXPLORE;
-	this->initialized_ = true;
+    last_mode_ = FRONTIER_EXPLORE;
+    this->initialized_ = true;
 
-	/*
-	 * reset all counter variables, used to count the number of according blocks
-	 * within the occupancy grid.
-	 */
-	unknown = 0, free = 0, lethal = 0, inflated = 0;
-       
+    /*
+     * reset all counter variables, used to count the number of according blocks
+     * within the occupancy grid.
+     */
+    unknown = 0, free = 0, lethal = 0, inflated = 0;
+
 }
 
 
 bool ExplorationPlanner::clusterFrontiers()
 {
-//    ROS_INFO("Clustering frontiers");
-    
+    //    ROS_INFO("Clustering frontiers");
+
     int strategy = 1;
     /*
      * Strategy:
      * 1 ... merge clusters close together
      * 2 ... merge clusters based on model
      */
-    
+
     bool cluster_found_flag = false, same_id = false;
-    
-        for(int i = 0; i < frontiers.size(); i++)
+
+    for (int i = 0; i < frontiers.size(); i++)
+    {
+        ROS_DEBUG("Frontier at: %d   and cluster size: %zu", i, clusters.size());
+        cluster_found_flag = false;
+        bool frontier_used = false;
+        same_id = false;
+
+        for (int j = 0; j < clusters.size(); j++)
         {
-            ROS_DEBUG("Frontier at: %d   and cluster size: %zu",i, clusters.size());
-            cluster_found_flag = false;
-            bool frontier_used = false;
-            same_id = false;
-            
-            for(int j = 0; j < clusters.size(); j++)
+            ROS_DEBUG("cluster %d contains %zu elements", j, clusters.at(j).cluster_element.size());
+            for (int n = 0; n < clusters.at(j).cluster_element.size(); n++)
             {
-                ROS_DEBUG("cluster %d contains %zu elements", j, clusters.at(j).cluster_element.size());
-                for(int n = 0; n < clusters.at(j).cluster_element.size(); n++)
+                ROS_DEBUG("accessing cluster %d  and element: %d", j, n);
+
+                if (fabs(frontiers.at(i).x_coordinate - clusters.at(j).cluster_element.at(n).x_coordinate) < MAX_NEIGHBOR_DIST &&
+                    fabs(frontiers.at(i).y_coordinate - clusters.at(j).cluster_element.at(n).y_coordinate) < MAX_NEIGHBOR_DIST)
                 {
-                   ROS_DEBUG("accessing cluster %d  and element: %d", j, n);
-                   
-                   if(fabs(frontiers.at(i).x_coordinate - clusters.at(j).cluster_element.at(n).x_coordinate) < MAX_NEIGHBOR_DIST && fabs(frontiers.at(i).y_coordinate - clusters.at(j).cluster_element.at(n).y_coordinate) < MAX_NEIGHBOR_DIST) 
-                   {    
-                       for(int m = 0; m < clusters.at(j).cluster_element.size(); m++)
-                       {    
-                          ROS_DEBUG("checking id %d with element id: %d",frontiers.at(i).id,clusters.at(j).cluster_element.at(m).id);
-                          
-                          if(robot_prefix_empty_param == true)
-                          {
-                              if(frontiers.at(i).id == clusters.at(j).cluster_element.at(m).id && frontiers.at(i).detected_by_robot_str.compare(clusters.at(j).cluster_element.at(m).detected_by_robot_str) == 0)
-                              {
-                                  ROS_DEBUG("SAME ID FOUND !!!!!!!");
-                                  frontier_used = true;
-                                  same_id = true;
-                                  break;
-                              } 
-                          }else
-                          {
-                              if(frontiers.at(i).id == clusters.at(j).cluster_element.at(m).id)
-                              {
-                                  ROS_DEBUG("SAME ID FOUND !!!!!!!");
-                                  frontier_used = true;
-                                  same_id = true;
-                                  break;
-                              } 
-                          }
-                          
-                          
-                       }  
-                       if(same_id == false)
-                       {
-                          cluster_found_flag = true; 
-                       }                 
-                   }
-                   if(same_id == true || cluster_found_flag == true)
-                   {
-                       break;
-                   }
-                } 
-                if(same_id == true)
+                    for (int m = 0; m < clusters.at(j).cluster_element.size(); m++)
+                    {
+                        ROS_DEBUG("checking id %d with element id: %d", frontiers.at(i).id, clusters.at(j).cluster_element.at(m).id);
+                        if (robot_prefix_empty_param == true)
+                        {
+                            if (frontiers.at(i).id == clusters.at(j).cluster_element.at(m).id &&
+                                frontiers.at(i).detected_by_robot_str.compare(clusters.at(j).cluster_element.at(m).detected_by_robot_str) == 0)
+                            {
+                                ROS_DEBUG("SAME ID FOUND !!!!!!!");
+                                frontier_used = true;
+                                same_id = true;
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            if (frontiers.at(i).id == clusters.at(j).cluster_element.at(m).id)
+                            {
+                                ROS_DEBUG("SAME ID FOUND !!!!!!!");
+                                frontier_used = true;
+                                same_id = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (same_id == false)
+                    {
+                        cluster_found_flag = true;
+                    }
+                }
+                if (same_id == true || cluster_found_flag == true)
                 {
                     break;
-                }else
-                {
-                    if(cluster_found_flag == true)
-                    {                    
-                        ROS_DEBUG("Frontier: %d attached", frontiers.at(i).id);
-                        clusters.at(j).cluster_element.push_back(frontiers.at(i));  
-                        frontier_used = true;
-                        break;
-                    }    
                 }
             }
-            if(cluster_found_flag == false && same_id == false)
+            if (same_id == true)
             {
-                ROS_DEBUG("ADD CLUSTER");
-                cluster_t cluster_new;
-                cluster_new.cluster_element.push_back(frontiers.at(i));
-                cluster_new.id = (robot_name * 10000) + cluster_id++;
-                
-                cluster_mutex.lock();
-                clusters.push_back(cluster_new); 
-                cluster_mutex.unlock();
-                
-                ROS_DEBUG("Frontier: %d in new cluster", frontiers.at(i).id);
-                frontier_used = true;
-            }   
-            if(frontier_used == false)
-            {
-                ROS_WARN("Frontier: %d not used", frontiers.at(i).id);
+                break;
             }
-        }  
-    
-    
+            else
+            {
+                if (cluster_found_flag == true)
+                {
+                    ROS_DEBUG("Frontier: %d attached", frontiers.at(i).id);
+                    clusters.at(j).cluster_element.push_back(frontiers.at(i));
+                    frontier_used = true;
+                    break;
+                }
+            }
+        }
+        if (cluster_found_flag == false && same_id == false)
+        {
+            ROS_DEBUG("ADD CLUSTER");
+            cluster_t cluster_new;
+            cluster_new.cluster_element.push_back(frontiers.at(i));
+            cluster_new.id = (robot_name * 10000) + cluster_id++;
+
+            cluster_mutex.lock();
+            clusters.push_back(cluster_new);
+            cluster_mutex.unlock();
+
+            ROS_DEBUG("Frontier: %d in new cluster", frontiers.at(i).id);
+            frontier_used = true;
+        }
+        if(frontier_used == false)
+        {
+            ROS_WARN("Frontier: %d not used", frontiers.at(i).id);
+        }
+    }
+
     /*
      * To finish the process finally check whether a cluster is close to another one.
      * If so, merge them.
      */
-    bool run_without_merging = false; 
-    
-    if(strategy == 1)
+    bool run_without_merging = false;
+
+    if (strategy == 1)
     {
-        while(run_without_merging == false)
+        while (run_without_merging == false)
         {
-            bool merge_clusters = false; 
-            for(int i = 0; i < clusters.size(); i++)
+            bool merge_clusters = false;
+            for (int i = 0; i < clusters.size(); i++)
             {
-                for(int m = 0; m < clusters.at(i).cluster_element.size(); m ++)
-                {   
-                    if(clusters.at(i).cluster_element.size() > 1)
+                for (int m = 0; m < clusters.at(i).cluster_element.size(); m ++)
+                {
+                    if (clusters.at(i).cluster_element.size() > 1)
                     {
-                        for(int j = 0; j < clusters.size(); j++)
+                        for (int j = 0; j < clusters.size(); j++)
                         {
-                            if(clusters.at(i).id != clusters.at(j).id)
+                            if (clusters.at(i).id != clusters.at(j).id)
                             {
-                                if(clusters.at(j).cluster_element.size() > 1)
-                                {                            
-                                    for(int n = 0; n < clusters.at(j).cluster_element.size(); n++)
-                                    { 
-                                        if(fabs(clusters.at(i).cluster_element.at(m).x_coordinate - clusters.at(j).cluster_element.at(n).x_coordinate) < CLUSTER_MERGING_DIST && fabs(clusters.at(i).cluster_element.at(m).y_coordinate - clusters.at(j).cluster_element.at(n).y_coordinate) < CLUSTER_MERGING_DIST)
-                                        {                   
-    //                                        ROS_INFO("Merge cluster %d", clusters.at(j).id);
-                                            merge_clusters = true; 
-                                            break;                                   
+                                if (clusters.at(j).cluster_element.size() > 1)
+                                {
+                                    for (int n = 0; n < clusters.at(j).cluster_element.size(); n++)
+                                    {
+                                        if(fabs(clusters.at(i).cluster_element.at(m).x_coordinate - clusters.at(j).cluster_element.at(n).x_coordinate) < CLUSTER_MERGING_DIST &&
+                                           fabs(clusters.at(i).cluster_element.at(m).y_coordinate - clusters.at(j).cluster_element.at(n).y_coordinate) < CLUSTER_MERGING_DIST)
+                                        {
+                                            // ROS_INFO("Merge cluster %d", clusters.at(j).id);
+                                            merge_clusters = true;
+                                            break;
                                         }
                                     }
-                                    if(merge_clusters == true)
+                                    if (merge_clusters == true)
                                     {
                                         /*
                                          * Now merge cluster i with cluster j.
@@ -429,7 +430,7 @@ bool ExplorationPlanner::clusterFrontiers()
                                             frontier_to_merge = clusters.at(j).cluster_element.at(n);
                                             clusters.at(i).cluster_element.push_back(frontier_to_merge);
                                         }
-    //                                    ROS_INFO("Erasing cluster %d", clusters.at(j).id);
+                                        // ROS_INFO("Erasing cluster %d", clusters.at(j).id);
                                         clusters.erase(clusters.begin() + j);
                                         break;
                                     }
@@ -437,58 +438,64 @@ bool ExplorationPlanner::clusterFrontiers()
                             }
                         }
                     }
-                    if(merge_clusters == true)
+                    if (merge_clusters == true)
+                    {
                         break;
+                    }
                 }
-                if(merge_clusters == true)
+                if (merge_clusters == true)
+                {
                     break;
+                }
             }
-            if(merge_clusters == false)
+            if (merge_clusters == false)
             {
                 run_without_merging = true;
-            }  
-    //        ROS_INFO("RUN WITHOUT MERGING: %d", run_without_merging);
-        } 
+            }
+            // ROS_INFO("RUN WITHOUT MERGING: %d", run_without_merging);
+        }
     }
-    else if(strategy == 2)
+    else if (strategy == 2)
     {
         int MAX_NEIGHBOURS = 4;
         double costmap_resolution = costmap_ros_->getCostmap()->getResolution();
-        
-        while(run_without_merging == false)
+
+        while (run_without_merging == false)
         {
-            bool merge_clusters = false; 
-            for(int i = 0; i < clusters.size(); i++)
+            bool merge_clusters = false;
+            for (int i = 0; i < clusters.size(); i++)
             {
-                for(int m = 0; m < clusters.at(i).cluster_element.size(); m ++)
-                {   
-                    if(clusters.at(i).cluster_element.size() > 1)
+                for (int m = 0; m < clusters.at(i).cluster_element.size(); m ++)
+                {
+                    if (clusters.at(i).cluster_element.size() > 1)
                     {
-                        for(int j = 0; j < clusters.size(); j++)
+                        for (int j = 0; j < clusters.size(); j++)
                         {
-                            if(clusters.at(i).id != clusters.at(j).id)
+                            if (clusters.at(i).id != clusters.at(j).id)
                             {
-                                if(clusters.at(j).cluster_element.size() > 1)
-                                {                            
-                                    for(int n = 0; n < clusters.at(j).cluster_element.size(); n++)
-                                    { 
+                                if (clusters.at(j).cluster_element.size() > 1)
+                                {
+                                    for (int n = 0; n < clusters.at(j).cluster_element.size(); n++)
+                                    {
                                         unsigned char cost;
                                         unsigned int mx,my;
                                         int freespace_detected = 0;
                                         int obstacle_detected  = 0;
-                                        int elements_detected = 0; 
-                                        
+                                        int elements_detected = 0;
+
                                         ROS_INFO("Calculating ...");
-                                        int x_length = abs(clusters.at(i).cluster_element.at(m).x_coordinate - clusters.at(j).cluster_element.at(n).x_coordinate);
-                                        int y_length = abs(clusters.at(i).cluster_element.at(m).y_coordinate - clusters.at(j).cluster_element.at(n).y_coordinate);
-                                        
+                                        int x_length = std::abs((int)(clusters.at(i).cluster_element.at(m).x_coordinate -
+                                                                      clusters.at(j).cluster_element.at(n).x_coordinate));
+                                        int y_length = std::abs((int)(clusters.at(i).cluster_element.at(m).y_coordinate -
+                                                                      clusters.at(j).cluster_element.at(n).y_coordinate));
+
                                         ROS_INFO("x_length: %d    y_length: %d   resolution: %f", x_length, y_length,costmap_resolution);
-                                        int x_elements = abs(x_length / costmap_resolution);
-                                        int y_elements = abs(y_length / costmap_resolution);
-                                        
+                                        int x_elements = std::abs((int)(x_length / costmap_resolution));
+                                        int y_elements = std::abs((int)(y_length / costmap_resolution));
+
                                         ROS_INFO("alpha");
-                                        double alpha; 
-                                        if(x_length == 0)
+                                        double alpha;
+                                        if (x_length == 0)
                                         {
                                             alpha = 0;
                                         }
@@ -496,90 +503,98 @@ bool ExplorationPlanner::clusterFrontiers()
                                         {
                                             alpha = atan(y_length/x_length);
                                         }
-                                        
+
                                         ROS_INFO("atan: %f   x_length: %d    y_length: %d", alpha, x_length, y_length);
-                                        
-                                        for(int x = 0; x <= x_elements; x++)
-                                        {      
+
+                                        for (int x = 0; x <= x_elements; x++)
+                                        {
                                             /* increase neighbor size*/
-                                            for(int neighbour = 0; neighbour < MAX_NEIGHBOURS; neighbour++)
+                                            for (int neighbour = 0; neighbour < MAX_NEIGHBOURS; neighbour++)
                                             {
-                                                int y = tan(alpha) * x * costmap_ros_->getCostmap()->getResolution();
+                                                int y = tan(alpha)*x*costmap_ros_->getCostmap()->getResolution();
                                                 ROS_INFO("x: %d    y: %d", x, y);
-                                                if(!costmap_global_ros_->getCostmap()->worldToMap(clusters.at(i).cluster_element.at(m).x_coordinate + x, clusters.at(i).cluster_element.at(m).y_coordinate + y + neighbour,mx,my))
+                                                if (!costmap_global_ros_->getCostmap()->worldToMap(
+                                                       clusters.at(i).cluster_element.at(m).x_coordinate + x,
+                                                       clusters.at(i).cluster_element.at(m).y_coordinate + y + neighbour,
+                                                       mx,
+                                                       my))
                                                 {
                                                     ROS_ERROR("Cannot convert coordinates successfully.");
                                                     continue;
                                                 }
-                                                cost = costmap_global_ros_->getCostmap()->getCost(mx, my);  
-                                               
-                                                if(cost == costmap_2d::FREE_SPACE)
+                                                cost = costmap_global_ros_->getCostmap()->getCost(mx, my);
+
+                                                if (cost == costmap_2d::FREE_SPACE)
                                                 {
                                                     freespace_detected = true;
                                                 }
-                                                else if(cost == costmap_2d::LETHAL_OBSTACLE)
+                                                else if (cost == costmap_2d::LETHAL_OBSTACLE)
                                                 {
                                                     obstacle_detected = true;
                                                 }
                                                 elements_detected++;
-                                            }  
-                                            
+                                            }
+
                                             /* decrease neighbor size*/
-                                            for(int neighbour = 0; neighbour < MAX_NEIGHBOURS; neighbour++)
+                                            for (int neighbour = 0; neighbour < MAX_NEIGHBOURS; neighbour++)
                                             {
-                                                int y = tan(alpha) * x * costmap_ros_->getCostmap()->getResolution();
+                                                int y = tan(alpha)*x*costmap_ros_->getCostmap()->getResolution();
                                                 ROS_INFO("x: %d    y: %d", x, y);
-                                                if(!costmap_global_ros_->getCostmap()->worldToMap(clusters.at(i).cluster_element.at(m).x_coordinate + x, clusters.at(i).cluster_element.at(m).y_coordinate + y - neighbour,mx,my))
+                                                if (!costmap_global_ros_->getCostmap()->worldToMap(
+                                                       clusters.at(i).cluster_element.at(m).x_coordinate + x,
+                                                       clusters.at(i).cluster_element.at(m).y_coordinate + y - neighbour,
+                                                       mx,
+                                                       my))
                                                 {
                                                     ROS_ERROR("Cannot convert coordinates successfully.");
                                                     continue;
                                                 }
-                                                cost = costmap_global_ros_->getCostmap()->getCost(mx, my);  
-                                               
-                                                if(cost == costmap_2d::FREE_SPACE)
+                                                cost = costmap_global_ros_->getCostmap()->getCost(mx, my);
+
+                                                if (cost == costmap_2d::FREE_SPACE)
                                                 {
                                                     freespace_detected = true;
                                                 }
-                                                else if(cost == costmap_2d::LETHAL_OBSTACLE)
+                                                else if (cost == costmap_2d::LETHAL_OBSTACLE)
                                                 {
                                                     obstacle_detected = true;
                                                 }
                                                 elements_detected++;
-                                            }  
+                                            }
                                         }
-                                        
-                                        
+
                                         ROS_INFO("*******************************");
                                         ROS_INFO("elements: %d    obstacle: %d", elements_detected, obstacle_detected);
                                         ROS_INFO("*******************************");
-                                        if(elements_detected * 0.25 < obstacle_detected)
+                                        if (elements_detected * 0.25 < obstacle_detected)
                                         {
                                             ROS_INFO("Merging clusters");
-                                            merge_clusters = true; 
-                                            break; 
+                                            merge_clusters = true;
+                                            break;
                                         }
                                         break;
-//                                        if(fabs(clusters.at(i).cluster_element.at(m).x_coordinate - clusters.at(j).cluster_element.at(n).x_coordinate) < CLUSTER_MERGING_DIST && fabs(clusters.at(i).cluster_element.at(m).y_coordinate - clusters.at(j).cluster_element.at(n).y_coordinate) < CLUSTER_MERGING_DIST)
-//                                        {                   
-//    //                                        ROS_INFO("Merge cluster %d", clusters.at(j).id);
-//                                            merge_clusters = true; 
-//                                            break;                                   
-//                                        }
+                                        // if (fabs(clusters.at(i).cluster_element.at(m).x_coordinate - clusters.at(j).cluster_element.at(n).x_coordinate) < CLUSTER_MERGING_DIST &&
+                                        //     fabs(clusters.at(i).cluster_element.at(m).y_coordinate - clusters.at(j).cluster_element.at(n).y_coordinate) < CLUSTER_MERGING_DIST)
+                                        // {
+                                        //     ROS_INFO("Merge cluster %d", clusters.at(j).id);
+                                        //     merge_clusters = true;
+                                        //     break;
+                                        // }
                                     }
-                                    if(merge_clusters == true)
+                                    if (merge_clusters == true)
                                     {
                                         ROS_INFO("Merging");
                                         /*
                                          * Now merge cluster i with cluster j.
                                          * afterwards delete cluster j.
                                          */
-                                        for(int n = 0; n < clusters.at(j).cluster_element.size(); n++)
+                                        for (int n = 0; n < clusters.at(j).cluster_element.size(); n++)
                                         {
                                             frontier_t frontier_to_merge;
                                             frontier_to_merge = clusters.at(j).cluster_element.at(n);
                                             clusters.at(i).cluster_element.push_back(frontier_to_merge);
                                         }
-    //                                    ROS_INFO("Erasing cluster %d", clusters.at(j).id);
+                                        // ROS_INFO("Erasing cluster %d", clusters.at(j).id);
                                         clusters.erase(clusters.begin() + j);
                                         j--;
                                         ROS_INFO("Done merging");
@@ -590,36 +605,52 @@ bool ExplorationPlanner::clusterFrontiers()
                             break;
                         }
                     }
-                    if(merge_clusters == true)
+                    if (merge_clusters == true)
+                    {
                         break;
+                    }
                 }
-                if(merge_clusters == true)
+                if (merge_clusters == true)
+                {
                     break;
+                }
             }
-            if(merge_clusters == false)
+            if (merge_clusters == false)
             {
                 run_without_merging = true;
-            }  
-    //        ROS_INFO("RUN WITHOUT MERGING: %d", run_without_merging);
-        } 
-    }   
+            }
+            // ROS_INFO("RUN WITHOUT MERGING: %d", run_without_merging);
+        }
+    }
+    return true;
 }
 
 void ExplorationPlanner::visualizeClustersConsole()
 {
     ROS_DEBUG("------------------------------------------------------------------");
-    for(int j = 0; j < clusters.size(); j++)
+    for (int j = 0; j < clusters.size(); j++)
     {
-        for(int n = 0; n < clusters.at(j).cluster_element.size(); n++)
+        for (int n = 0; n < clusters.at(j).cluster_element.size(); n++)
         {
-            if(robot_prefix_empty_param == true)
+            if (robot_prefix_empty_param == true)
             {
-                ROS_DEBUG("ID: %6d  x: %5.2f  y: %5.2f  cluster: %5d   robot: %s", clusters.at(j).cluster_element.at(n).id, clusters.at(j).cluster_element.at(n).x_coordinate, clusters.at(j).cluster_element.at(n).y_coordinate, clusters.at(j).id, clusters.at(j).cluster_element.at(n).detected_by_robot_str.c_str());
-            }else
+                ROS_DEBUG("ID: %6d  x: %5.2f  y: %5.2f  cluster: %5d   robot: %s",
+                          clusters.at(j).cluster_element.at(n).id,
+                          clusters.at(j).cluster_element.at(n).x_coordinate,
+                          clusters.at(j).cluster_element.at(n).y_coordinate,
+                          clusters.at(j).id,
+                          clusters.at(j).cluster_element.at(n).detected_by_robot_str.c_str());
+            }
+            else
             {
-                ROS_DEBUG("ID: %6d  x: %5.2f  y: %5.2f  cluster: %5d   dist: %d", clusters.at(j).cluster_element.at(n).id, clusters.at(j).cluster_element.at(n).x_coordinate, clusters.at(j).cluster_element.at(n).y_coordinate, clusters.at(j).id, clusters.at(j).cluster_element.at(n).dist_to_robot);
-            }            
-        }           
+                ROS_DEBUG("ID: %6d  x: %5.2f  y: %5.2f  cluster: %5d   dist: %d",
+                          clusters.at(j).cluster_element.at(n).id,
+                          clusters.at(j).cluster_element.at(n).x_coordinate,
+                          clusters.at(j).cluster_element.at(n).y_coordinate,
+                          clusters.at(j).id,
+                          clusters.at(j).cluster_element.at(n).dist_to_robot);
+            }
+        }
     }
     ROS_DEBUG("------------------------------------------------------------------");
 }
@@ -633,64 +664,71 @@ void ExplorationPlanner::visualizeClustersConsole()
 //    if(robot_name_int == 2)
 //        return ("marley");
 //    if(robot_name_int == 3)
-//        return ("bob"); 
+//        return ("bob");
 //    if(robot_name_int == 4)
-//        return ("hans"); 
+//        return ("hans");
 //}
 
 bool ExplorationPlanner::transformToOwnCoordinates_frontiers()
 {
     ROS_INFO("Transform frontier coordinates");
-    
+
     store_frontier_mutex.lock();
-    
-    for(int i = 0; i < frontiers.size(); i++)
-    {        
+
+    for (int i = 0; i < frontiers.size(); i++)
+    {
         bool same_robot = false;
-        if(robot_prefix_empty_param == true)
+        if (robot_prefix_empty_param == true)
         {
-            if(frontiers.at(i).detected_by_robot_str.compare(robot_str) == 0)
-                same_robot = true;
-//                ROS_ERROR("Same Robot Detected");
-        }else
-        {
-            if(frontiers.at(i).detected_by_robot == robot_name)
-                same_robot = true; 
-        }
-        if(same_robot == false)
-        {
-//            ROS_ERROR("Same robot is false");
-            bool transform_flag = false;
-            for(int j=0; j < transformedPointsFromOtherRobot_frontiers.size(); j++)
+            if (frontiers.at(i).detected_by_robot_str.compare(robot_str) == 0)
             {
-                if(robot_prefix_empty_param == 0)
+                same_robot = true;
+            }
+            // ROS_ERROR("Same Robot Detected");
+        }
+        else
+        {
+            if (frontiers.at(i).detected_by_robot == robot_name)
+            {
+                same_robot = true;
+            }
+        }
+        if (same_robot == false)
+        {
+            // ROS_ERROR("Same robot is false");
+            bool transform_flag = false;
+            for (int j=0; j < transformedPointsFromOtherRobot_frontiers.size(); j++)
+            {
+                if (robot_prefix_empty_param == 0)
                 {
-                    if(transformedPointsFromOtherRobot_frontiers.at(j).id == frontiers.at(i).id && frontiers.at(i).detected_by_robot_str.compare(transformedPointsFromOtherRobot_frontiers.at(j).robot_str)== 0)
+                    if (transformedPointsFromOtherRobot_frontiers.at(j).id == frontiers.at(i).id &&
+                        frontiers.at(i).detected_by_robot_str.compare(transformedPointsFromOtherRobot_frontiers.at(j).robot_str)== 0)
                     {
                         transform_flag = true;
                         break;
                     }
-                }else
+                }
+                else
                 {
-                    if(transformedPointsFromOtherRobot_frontiers.at(j).id == frontiers.at(i).id)
+                    if (transformedPointsFromOtherRobot_frontiers.at(j).id == frontiers.at(i).id)
                     {
                         transform_flag = true;
                         break;
                     }
-                }     
+                }
             }
 
-            if(transform_flag != true)
+            if (transform_flag != true)
             {
                 std::string robo_name, robo_name2;
-                
+
                 if(robot_prefix_empty_param == false)
                 {
                     std::stringstream robot_number;
                     robot_number << frontiers.at(i).detected_by_robot;
-                
+
                     std::string prefix = "robot_";
-                    robo_name = prefix.append(robot_number.str());                
+                    robo_name = prefix.append(robot_number.str());
                     ROS_DEBUG("Robots name is        %s", robo_name.c_str());
 
                     std::stringstream robot_number2;
@@ -700,85 +738,92 @@ bool ExplorationPlanner::transformToOwnCoordinates_frontiers()
                     robo_name2 = prefix2.append(robot_number2.str());
                 }
                 else
-                {      
+                {
 //                    ROS_ERROR("Get Robot Name ... ");
-//                    robo_name = lookupRobotName(frontiers.at(i).detected_by_robot);                  
+//                    robo_name = lookupRobotName(frontiers.at(i).detected_by_robot);
 //                    robo_name2 = lookupRobotName(robot_name);
                     robo_name = frontiers.at(i).detected_by_robot_str;
                     robo_name2 = robot_str;
                     ROS_DEBUG("Robot: %s   transforms from robot: %s", robo_name2.c_str(), robo_name.c_str());
                 }
-                
-                
-                
+
                 std::string service_topic = robo_name2.append("/map_merger/transformPoint"); // FIXME for real scenario!!! robot_might not be used here
 
 //              ROS_INFO("Robo name: %s   Service to subscribe to: %s", robo_name.c_str(), service_topic.c_str());
-              
+
                 client = nh_transform.serviceClient<map_merger::TransformPoint>(service_topic);
-                
+
                 service_message.request.point.x = frontiers.at(i).x_coordinate;
                 service_message.request.point.y = frontiers.at(i).y_coordinate;
                 service_message.request.point.src_robot = robo_name;
 
                 ROS_DEBUG("Robot name:  %s", service_message.request.point.src_robot.c_str());
                 ROS_DEBUG("Old x: %f   y: %f", frontiers.at(i).x_coordinate, frontiers.at(i).y_coordinate);
-               
-                if(client.call(service_message))
+
+                if (client.call(service_message))
                 {
-                    frontiers.at(i).x_coordinate = service_message.response.point.x; 
+                    frontiers.at(i).x_coordinate = service_message.response.point.x;
                     frontiers.at(i).y_coordinate = service_message.response.point.y;
 
                     transform_point_t transform_point;
                     transform_point.id = frontiers.at(i).id;
-                                        
-                    if(robot_prefix_empty_param == true)
+
+                    if (robot_prefix_empty_param == true)
                     {
                         transform_point.robot_str = frontiers.at(i).detected_by_robot_str;
                     }
                     transformedPointsFromOtherRobot_frontiers.push_back(transform_point);
-                    ROS_DEBUG("New x: %.1f   y: %.1f",service_message.response.point.x, service_message.response.point.y);                   
+                    ROS_DEBUG("New x: %.1f   y: %.1f",
+                              service_message.response.point.x,
+                              service_message.response.point.y);
                 }
             }
         }
     }
     store_frontier_mutex.unlock();
     ROS_INFO(" Transform frontier coordinates DONE");
+    return true;
 }
-
 
 bool ExplorationPlanner::transformToOwnCoordinates_visited_frontiers()
 {
     ROS_INFO("Transform Visited Frontier Coordinates");
-    
-    for(int i = 0; i < visited_frontiers.size(); i++)
+
+    for (int i = 0; i < visited_frontiers.size(); i++)
     {
         bool same_robot = false;
-        if(robot_prefix_empty_param == true)
+        if (robot_prefix_empty_param == true)
         {
-            if(visited_frontiers.at(i).detected_by_robot_str.compare(robot_str) == 0)
+            if (visited_frontiers.at(i).detected_by_robot_str.compare(robot_str) == 0)
+            {
                 same_robot = true;
-//                ROS_ERROR("Same Robot Detected");
-        }else
-        {
-            if(visited_frontiers.at(i).detected_by_robot == robot_name)
-                same_robot = true; 
+                // ROS_ERROR("Same Robot Detected");
+            }
         }
-        if(same_robot == false)
+        else
+        {
+            if (visited_frontiers.at(i).detected_by_robot == robot_name)
+            {
+                same_robot = true;
+            }
+        }
+        if (same_robot == false)
         {
             bool transform_flag = false;
-            for(int j=0; j < transformedPointsFromOtherRobot_visited_frontiers.size(); j++)
+            for (int j=0; j < transformedPointsFromOtherRobot_visited_frontiers.size(); j++)
             {
-                if(robot_prefix_empty_param == 0)
+                if (robot_prefix_empty_param == 0)
                 {
-                    if(transformedPointsFromOtherRobot_visited_frontiers.at(j).id == visited_frontiers.at(i).id && visited_frontiers.at(i).detected_by_robot_str.compare(transformedPointsFromOtherRobot_visited_frontiers.at(j).robot_str)== 0)
+                    if (transformedPointsFromOtherRobot_visited_frontiers.at(j).id == visited_frontiers.at(i).id &&
+                        visited_frontiers.at(i).detected_by_robot_str.compare(transformedPointsFromOtherRobot_visited_frontiers.at(j).robot_str)== 0)
                     {
                         transform_flag = true;
                         break;
                     }
-                }else
+                }
+                else
                 {
-                    if(transformedPointsFromOtherRobot_visited_frontiers.at(j).id == visited_frontiers.at(i).id)
+                    if (transformedPointsFromOtherRobot_visited_frontiers.at(j).id == visited_frontiers.at(i).id)
                     {
                         transform_flag = true;
                         break;
@@ -786,18 +831,18 @@ bool ExplorationPlanner::transformToOwnCoordinates_visited_frontiers()
                 }
             }
 
-            if(transform_flag != true)
+            if (transform_flag != true)
             {
-                
+
                 std::string robo_name, robo_name2;
-                
-                if(robot_prefix_empty_param == false)
+
+                if (robot_prefix_empty_param == false)
                 {
                     std::stringstream robot_number;
                     robot_number << visited_frontiers.at(i).detected_by_robot;
-                
+
                     std::string prefix = "robot_";
-                    robo_name = prefix.append(robot_number.str());                
+                    robo_name = prefix.append(robot_number.str());
                     ROS_DEBUG("Robots name is        %s", robo_name.c_str());
 
                     std::stringstream robot_number2;
@@ -807,61 +852,63 @@ bool ExplorationPlanner::transformToOwnCoordinates_visited_frontiers()
                     robo_name2 = prefix2.append(robot_number2.str());
                 }
                 else
-                {                   
-//                    robo_name = lookupRobotName(visited_frontiers.at(i).detected_by_robot);                  
-//                    robo_name2 = lookupRobotName(robot_name);
-                    
+                {
+                    // robo_name = lookupRobotName(visited_frontiers.at(i).detected_by_robot);
+                    // robo_name2 = lookupRobotName(robot_name);
+
                     robo_name = visited_frontiers.at(i).detected_by_robot_str;
                     robo_name2 = robot_str;
-                     ROS_DEBUG("Robot: %s   transforms from robot: %s", robo_name2.c_str(), robo_name.c_str());
+                    ROS_DEBUG("Robot: %s   transforms from robot: %s", robo_name2.c_str(), robo_name.c_str());
                 }
-                
-                
+
                 std::string service_topic = robo_name2.append("/map_merger/transformPoint"); // FIXME for real scenario!!! robot_ might not be used here
-               
+
                 client = nh_transform.serviceClient<map_merger::TransformPoint>(service_topic);
-                
+
                 service_message.request.point.x = visited_frontiers.at(i).x_coordinate;
                 service_message.request.point.y = visited_frontiers.at(i).y_coordinate;
                 service_message.request.point.src_robot = robo_name;
 
-                ROS_DEBUG("Old visited x: %f   y: %f", visited_frontiers.at(i).x_coordinate, visited_frontiers.at(i).y_coordinate);
-               
-                if(client.call(service_message))
+                ROS_DEBUG("Old visited x: %f   y: %f",
+                          visited_frontiers.at(i).x_coordinate,
+                          visited_frontiers.at(i).y_coordinate);
+
+                if (client.call(service_message))
                 {
                     visited_frontiers.at(i).x_coordinate = service_message.response.point.x;
                     visited_frontiers.at(i).y_coordinate = service_message.response.point.y;
 
                     transform_point_t transform_point;
                     transform_point.id = visited_frontiers.at(i).id;
-                    
-                    if(robot_prefix_empty_param == true)
+
+                    if (robot_prefix_empty_param == true)
                     {
                         transform_point.robot_str = visited_frontiers.at(i).detected_by_robot_str;
                     }
                     transformedPointsFromOtherRobot_visited_frontiers.push_back(transform_point);
-                    ROS_DEBUG("New visited x: %.1f   y: %.1f",service_message.response.point.x, service_message.response.point.y);                   
+                    ROS_DEBUG("New visited x: %.1f   y: %.1f",
+                              service_message.response.point.x,
+                              service_message.response.point.y);
                 }
             }
         }
     }
     ROS_INFO(" Transform visited frontier coordinates DONE");
+    return true;
 }
 
-
-
 bool ExplorationPlanner::check_trajectory_plan()
-{       
+{
     geometry_msgs::PoseStamped goalPointSimulated, startPointSimulated;
-    int distance; 
-    
+    int distance;
+
     ROS_INFO("Check Trajectory Length");
     if (!costmap_global_ros_->getRobotPose(robotPose))
     {
-            ROS_ERROR("Failed to get RobotPose");
+        ROS_ERROR("Failed to get RobotPose");
     }
 
-    startPointSimulated.header.seq = start_point_simulated_message++;	// increase the sequence number
+    startPointSimulated.header.seq = start_point_simulated_message++; // increase the sequence number
     startPointSimulated.header.stamp = ros::Time::now();
     startPointSimulated.header.frame_id = move_base_frame;
     startPointSimulated.pose.position.x = robotPose.getOrigin().getX();
@@ -872,24 +919,28 @@ bool ExplorationPlanner::check_trajectory_plan()
     startPointSimulated.pose.orientation.z = robotPose.getRotation().getZ();
     startPointSimulated.pose.orientation.w = 1;
 
-    for(int i = 0; i<10; i++)
+    for (int i = 0; i<10; i++)
     {
-        if(frontiers.size() > i)
-        {   
+        if (frontiers.size() > i)
+        {
             std::vector<double> backoffGoal;
-            bool backoff_flag = smartGoalBackoff(frontiers.at(i).x_coordinate,frontiers.at(i).y_coordinate, costmap_global_ros_, &backoffGoal);
-            
-            
-            goalPointSimulated.header.seq = goal_point_simulated_message++;	// increase the sequence number
+            bool backoff_flag = smartGoalBackoff(frontiers.at(i).x_coordinate,
+                                                 frontiers.at(i).y_coordinate,
+                                                 costmap_global_ros_,
+                                                 &backoffGoal);
+
+
+            goalPointSimulated.header.seq = goal_point_simulated_message++; // increase the sequence number
             goalPointSimulated.header.stamp = ros::Time::now();
             goalPointSimulated.header.frame_id = move_base_frame;
-            
-//            backoff_flag = false; // TODO
-            if(backoff_flag == true)
+
+            // backoff_flag = false; // TODO
+            if (backoff_flag == true)
             {
                 goalPointSimulated.pose.position.x = backoffGoal.at(0);
                 goalPointSimulated.pose.position.y = backoffGoal.at(1);
-            }else
+            }
+            else
             {
                 goalPointSimulated.pose.position.x = frontiers.at(i).x_coordinate;
                 goalPointSimulated.pose.position.y = frontiers.at(i).y_coordinate;
@@ -906,31 +957,31 @@ bool ExplorationPlanner::check_trajectory_plan()
             distance =  global_plan.size();
             frontiers.at(i).distance_to_robot = distance;
 
-            ROS_DEBUG("Distance: %d Frontier: %d",distance, frontiers.at(i).id);
-        }else
+            ROS_DEBUG("Distance: %d Frontier: %d", distance, frontiers.at(i).id);
+        }
+        else
         {
             break;
         }
     }
     ROS_DEBUG("trajectory finished");
-    return(true);
+    return true;
 }
-
 
 int ExplorationPlanner::calculate_travel_path(double x, double y)
 {
         geometry_msgs::PoseStamped goalPointSimulated, startPointSimulated;
-    double distance; 
-    
+    double distance;
+
     ROS_DEBUG("Check Trajectory");
     if (!costmap_global_ros_->getRobotPose(robotPose))
-    {       
+    {
             ROS_ERROR("Failed to get RobotPose");
     }
 
     std::vector<double> backoffGoal;
     bool backoff_flag = smartGoalBackoff(x,y, costmap_global_ros_, &backoffGoal);
-            
+
     startPointSimulated.header.seq = start_point_simulated_message++;	// increase the sequence number
     startPointSimulated.header.stamp = ros::Time::now();
     startPointSimulated.header.frame_id = move_base_frame;
@@ -942,11 +993,11 @@ int ExplorationPlanner::calculate_travel_path(double x, double y)
     startPointSimulated.pose.orientation.z = 0;
     startPointSimulated.pose.orientation.w = 1;
 
-   
+
     goalPointSimulated.header.seq = goal_point_simulated_message++;	// increase the sequence number
     goalPointSimulated.header.stamp = ros::Time::now();
     goalPointSimulated.header.frame_id = move_base_frame;
-    
+
 //    backoff_flag = false; // TODO
     if(backoff_flag == true)
     {
@@ -966,13 +1017,13 @@ int ExplorationPlanner::calculate_travel_path(double x, double y)
     std::vector<geometry_msgs::PoseStamped> global_plan;
 
     bool successful = nav.makePlan(startPointSimulated, goalPointSimulated, global_plan);
-    
+
     ROS_INFO("Plan elements: %f", (double)global_plan.size()*0.02);
 
     if(successful == true)
     {
-        distance =  global_plan.size();   
-        exploration_travel_path_global = exploration_travel_path_global + distance;  
+        distance =  global_plan.size();
+        exploration_travel_path_global = exploration_travel_path_global + distance;
         return distance;
     }else
     {
@@ -981,19 +1032,19 @@ int ExplorationPlanner::calculate_travel_path(double x, double y)
 }
 
 int ExplorationPlanner::check_trajectory_plan(double x, double y)
-{       
+{
     geometry_msgs::PoseStamped goalPointSimulated, startPointSimulated;
-    int distance; 
-    
+    int distance;
+
     ROS_DEBUG("Check Trajectory");
     if (!costmap_global_ros_->getRobotPose(robotPose))
-    {       
+    {
             ROS_ERROR("Failed to get RobotPose");
     }
-   
+
     std::vector<double> backoffGoal;
     bool backoff_flag = smartGoalBackoff(x,y, costmap_global_ros_, &backoffGoal);
-    
+
     startPointSimulated.header.seq = start_point_simulated_message++;	// increase the sequence number
     startPointSimulated.header.stamp = ros::Time::now();
     startPointSimulated.header.frame_id = move_base_frame;
@@ -1005,11 +1056,11 @@ int ExplorationPlanner::check_trajectory_plan(double x, double y)
     startPointSimulated.pose.orientation.z = 0;
     startPointSimulated.pose.orientation.w = 1;
 
-   
+
     goalPointSimulated.header.seq = goal_point_simulated_message++;	// increase the sequence number
     goalPointSimulated.header.stamp = ros::Time::now();
     goalPointSimulated.header.frame_id = move_base_frame;
-    
+
 //    backoff_flag = false; // TODO
     if(backoff_flag == true)
     {
@@ -1033,10 +1084,10 @@ int ExplorationPlanner::check_trajectory_plan(double x, double y)
 //    tp.initialize("my_trajectory_planner", &tf_planner, &costmap_global_ros_);
 
     bool successful = nav.makePlan(startPointSimulated, goalPointSimulated, global_plan);
-    
+
     if(successful == true)
-    {       
-        distance =  global_plan.size();          
+    {
+        distance =  global_plan.size();
         return distance;
     }else
     {
@@ -1046,19 +1097,19 @@ int ExplorationPlanner::check_trajectory_plan(double x, double y)
 }
 
 int ExplorationPlanner::estimate_trajectory_plan(double start_x, double start_y, double target_x, double target_y)
-{       
+{
     geometry_msgs::PoseStamped goalPointSimulated, startPointSimulated;
-    int distance; 
-    
+    int distance;
+
     ROS_DEBUG("Check Trajectory");
     if (!costmap_ros_->getRobotPose(robotPose))
-    {       
+    {
             ROS_ERROR("Failed to get RobotPose");
     }
 
     std::vector<double> backoffGoal;
     bool backoff_flag = smartGoalBackoff(target_x,target_y, costmap_global_ros_, &backoffGoal);
-    
+
     startPointSimulated.header.seq = start_point_simulated_message++;	// increase the sequence number
     startPointSimulated.header.stamp = ros::Time::now();
     startPointSimulated.header.frame_id = move_base_frame;
@@ -1070,7 +1121,7 @@ int ExplorationPlanner::estimate_trajectory_plan(double start_x, double start_y,
     startPointSimulated.pose.orientation.z = 0;
     startPointSimulated.pose.orientation.w = 1;
 
-   
+
     goalPointSimulated.header.seq = goal_point_simulated_message++;	// increase the sequence number
     goalPointSimulated.header.stamp = ros::Time::now();
     goalPointSimulated.header.frame_id = move_base_frame;
@@ -1095,7 +1146,7 @@ int ExplorationPlanner::estimate_trajectory_plan(double start_x, double start_y,
 
     if(successful == true)
     {
-        distance =  global_plan.size();      
+        distance =  global_plan.size();
         return distance;
     }else
     {
@@ -1112,8 +1163,8 @@ void ExplorationPlanner::setRobotConfig(int name, double robot_home_position_x, 
 }
 
 void ExplorationPlanner::home_position_(const geometry_msgs::PointStamped::ConstPtr& msg) {
-	home_position_x_ = msg.get()->point.x;
-	home_position_y_ = msg.get()->point.y;
+    home_position_x_ = msg.get()->point.x;
+    home_position_y_ = msg.get()->point.y;
 }
 
 
@@ -1134,9 +1185,9 @@ void ExplorationPlanner::printFrontiers()
 bool ExplorationPlanner::storeFrontier(double x, double y, int detected_by_robot, std::string detected_by_robot_str, int id)
 {
     frontier_t new_frontier;
-    
+
     if(robot_prefix_empty_param == true)
-    {        
+    {
         ROS_DEBUG("Storing Frontier ID: %d   Robot: %s", id, detected_by_robot_str.c_str());
         if(id != -1)
         {
@@ -1149,7 +1200,7 @@ bool ExplorationPlanner::storeFrontier(double x, double y, int detected_by_robot
         new_frontier.x_coordinate = x;
         new_frontier.y_coordinate = y;
 
-        store_frontier_mutex.lock(); 
+        store_frontier_mutex.lock();
         frontiers.push_back(new_frontier);
         store_frontier_mutex.unlock();
     }else
@@ -1160,18 +1211,18 @@ bool ExplorationPlanner::storeFrontier(double x, double y, int detected_by_robot
         }
         else
         {
-           new_frontier.id = (robot_name * 10000) + frontier_id_count++; 
+           new_frontier.id = (robot_name * 10000) + frontier_id_count++;
         }
 
         new_frontier.detected_by_robot = detected_by_robot;
         new_frontier.x_coordinate = x;
         new_frontier.y_coordinate = y;
 
-        store_frontier_mutex.lock(); 
+        store_frontier_mutex.lock();
         frontiers.push_back(new_frontier);
         store_frontier_mutex.unlock();
     }
-    
+
     return true;
 }
 
@@ -1214,12 +1265,12 @@ bool ExplorationPlanner::removeStoredFrontier(int id, std::string detected_by_ro
 
 bool ExplorationPlanner::storeVisitedFrontier(double x, double y, int detected_by_robot, std::string detected_by_robot_str, int id)
 {
-   
+
     frontier_t visited_frontier;
-    
-    
+
+
     if(robot_prefix_empty_param == true)
-    {        
+    {
         ROS_DEBUG("Storing Visited Frontier ID: %d   Robot: %s", visited_frontier_id_count, detected_by_robot_str.c_str());
         if(id != -1)
         {
@@ -1228,7 +1279,7 @@ bool ExplorationPlanner::storeVisitedFrontier(double x, double y, int detected_b
         {
             visited_frontier.id = visited_frontier_id_count++;
         }
-        
+
         visited_frontier.detected_by_robot_str = detected_by_robot_str;
         visited_frontier.x_coordinate = x;
         visited_frontier.y_coordinate = y;
@@ -1236,7 +1287,7 @@ bool ExplorationPlanner::storeVisitedFrontier(double x, double y, int detected_b
         store_visited_mutex.lock();
         visited_frontiers.push_back(visited_frontier);
         store_visited_mutex.unlock();
-        
+
     }else
     {
          if(detected_by_robot != robot_name)
@@ -1245,7 +1296,7 @@ bool ExplorationPlanner::storeVisitedFrontier(double x, double y, int detected_b
         }
         else
         {
-           visited_frontier.id = (robot_name * 10000) + visited_frontier_id_count++; 
+           visited_frontier.id = (robot_name * 10000) + visited_frontier_id_count++;
         }
 
         visited_frontier.detected_by_robot = detected_by_robot;
@@ -1256,8 +1307,8 @@ bool ExplorationPlanner::storeVisitedFrontier(double x, double y, int detected_b
         visited_frontiers.push_back(visited_frontier);
         store_visited_mutex.unlock();
     }
-    
-    bool break_flag = false; 
+
+    bool break_flag = false;
     for(int i = 0; i < clusters.size(); i++)
     {
         for(int j = 0; j < clusters.at(i).cluster_element.size(); j++)
@@ -1266,16 +1317,16 @@ bool ExplorationPlanner::storeVisitedFrontier(double x, double y, int detected_b
             {
                 ROS_DEBUG("Set cluster unreachable count to 0");
                 clusters.at(i).unreachable_frontier_count = 0;
-                break_flag = true; 
+                break_flag = true;
                 break;
-            }           
+            }
         }
         if(break_flag == true)
         {
             break;
         }
     }
-    
+
     return true;
 }
 
@@ -1285,7 +1336,7 @@ bool ExplorationPlanner::removeVisitedFrontier(int id, std::string detected_by_r
     {
         if(robot_prefix_empty_param == true)
         {
-            
+
             if(visited_frontiers.at(i).id == id && visited_frontiers.at(i).detected_by_robot_str.compare(detected_by_robot_str) == 0)
             {
                 ROS_INFO("Removing Visited Frontier ID: %d  at position: %d  of Robot: %s", visited_frontiers.at(i).id, i, visited_frontiers.at(i).detected_by_robot_str.c_str());
@@ -1311,18 +1362,18 @@ bool ExplorationPlanner::removeVisitedFrontier(int id, std::string detected_by_r
                 store_visited_mutex.unlock();
                 break;
             }
-        } 
+        }
     }
-    return true; 
+    return true;
 }
 bool ExplorationPlanner::storeUnreachableFrontier(double x, double y, int detected_by_robot, std::string detected_by_robot_str, int id)
 {
     frontier_t unreachable_frontier;
-    
+
     if(robot_prefix_empty_param == true)
-    {        
+    {
         ROS_DEBUG("Storing Unreachable Frontier ID: %d   Robot: %s", unreachable_frontier_id_count, detected_by_robot_str.c_str());
-        
+
         if(id != -1)
         {
             unreachable_frontier.id = id;
@@ -1330,13 +1381,13 @@ bool ExplorationPlanner::storeUnreachableFrontier(double x, double y, int detect
         {
             unreachable_frontier.id = unreachable_frontier_id_count++;
         }
-        
+
         unreachable_frontier.detected_by_robot_str = detected_by_robot_str;
         unreachable_frontier.x_coordinate = x;
         unreachable_frontier.y_coordinate = y;
 
         unreachable_frontiers.push_back(unreachable_frontier);
-      
+
     }else
     {
         if(detected_by_robot != robot_name)
@@ -1345,7 +1396,7 @@ bool ExplorationPlanner::storeUnreachableFrontier(double x, double y, int detect
         }
         else
         {
-           unreachable_frontier.id = (robot_name * 10000) + unreachable_frontier_id_count++; 
+           unreachable_frontier.id = (robot_name * 10000) + unreachable_frontier_id_count++;
         }
 
         unreachable_frontier.detected_by_robot = detected_by_robot;
@@ -1354,9 +1405,9 @@ bool ExplorationPlanner::storeUnreachableFrontier(double x, double y, int detect
 
         frontiers.push_back(unreachable_frontier);
     }
-    
-    
-    bool break_flag = false; 
+
+
+    bool break_flag = false;
     for(int i = 0; i < clusters.size(); i++)
     {
         for(int j = 0; j < clusters.at(i).cluster_element.size(); j++)
@@ -1365,18 +1416,18 @@ bool ExplorationPlanner::storeUnreachableFrontier(double x, double y, int detect
             {
                 ROS_WARN("Increasing cluster unreachable count");
                 clusters.at(i).unreachable_frontier_count++;
-                break_flag = true; 
+                break_flag = true;
                 break;
-            }           
+            }
         }
         if(break_flag == true)
         {
             break;
         }
     }
-    
+
     return true;
-  
+
 }
 
 bool ExplorationPlanner::removeUnreachableFrontier(int id, std::string detected_by_robot_str)
@@ -1388,7 +1439,7 @@ bool ExplorationPlanner::removeUnreachableFrontier(int id, std::string detected_
             if(unreachable_frontiers.at(i).id == id && unreachable_frontiers.at(i).detected_by_robot_str.compare(detected_by_robot_str) == 0)
             {
                 ROS_INFO("Removing Unreachable Frontier ID: %d  at position: %d  of Robot: %s", unreachable_frontiers.at(i).id, i, unreachable_frontiers.at(i).detected_by_robot_str.c_str());
-               
+
                 unreachable_frontiers.erase(unreachable_frontiers.begin()+i);
 //                if(i > 0)
 //                {
@@ -1415,35 +1466,35 @@ bool ExplorationPlanner::removeUnreachableFrontier(int id, std::string detected_
 
 bool ExplorationPlanner::publish_negotiation_list(frontier_t negotiation_frontier, int cluster_number)
 {
-//    ROS_ERROR("Publish negotiation list!!!!!!!!!!!!!!!!");
+    // ROS_ERROR("Publish negotiation list!!!!!!!!!!!!!!!!");
     adhoc_communication::ExpFrontier negotiation_msg;
-    
-//    for(int i = 0; i<negotiation_list.size(); i++)
-//    {
-//        adhoc_communication::FrontierElement negotiation_element;
-//        negotiation_element.detected_by_robot = negotiation_list.at(i).detected_by_robot;
-//        negotiation_element.x_coordinate = negotiation_list.at(i).x_coordinate;
-//        negotiation_element.y_coordinate = negotiation_list.at(i).y_coordinate;
-//        negotiation_element.id = negotiation_list.at(i).id;
-//
-//        negotiation_msg.frontier_element.push_back(negotiation_element);
-////        pub_negotion.publish(negotiation_msg);
-//        шnitisendToMulticast("mc_",negotiation_msg, "negotiation_list");
-//    }
-    
-    if(cluster_number != -1)
+
+    //    for(int i = 0; i<negotiation_list.size(); i++)
+    //    {
+    //        adhoc_communication::FrontierElement negotiation_element;
+    //        negotiation_element.detected_by_robot = negotiation_list.at(i).detected_by_robot;
+    //        negotiation_element.x_coordinate = negotiation_list.at(i).x_coordinate;
+    //        negotiation_element.y_coordinate = negotiation_list.at(i).y_coordinate;
+    //        negotiation_element.id = negotiation_list.at(i).id;
+    //
+    //        negotiation_msg.frontier_element.push_back(negotiation_element);
+    //        pub_negotion.publish(negotiation_msg);
+    //        шnitisendToMulticast("mc_",negotiation_msg, "negotiation_list");
+    //    }
+
+    if (cluster_number != -1)
     {
         int cluster_vector_position = 0;
         for (int i = 0; i < clusters.size(); i++)
         {
-            if(clusters.at(i).id == cluster_number)
+            if (clusters.at(i).id == cluster_number)
             {
                 ROS_DEBUG("Cluster ID: %d   is at vector position: %d", cluster_number, i);
                 cluster_vector_position = i;
                 break;
             }
         }
-        
+
         for(int i = 0; i < clusters.at(cluster_vector_position).cluster_element.size(); i++)
         {
             adhoc_communication::ExpFrontierElement negotiation_element;
@@ -1457,12 +1508,13 @@ bool ExplorationPlanner::publish_negotiation_list(frontier_t negotiation_frontie
             new_frontier.y_coordinate = clusters.at(cluster_vector_position).cluster_element.at(i).y_coordinate;
             new_frontier.detected_by_robot = clusters.at(cluster_vector_position).cluster_element.at(i).detected_by_robot;
             new_frontier.id = clusters.at(cluster_vector_position).cluster_element.at(i).id;
-           
+
             negotiation_msg.frontier_element.push_back(negotiation_element);
             my_negotiation_list.push_back(new_frontier);
         }
-//        return true;
-    }else
+        // return true;
+    }
+    else
     {
         adhoc_communication::ExpFrontierElement negotiation_element;
         negotiation_element.detected_by_robot = negotiation_frontier.detected_by_robot;
@@ -1470,12 +1522,13 @@ bool ExplorationPlanner::publish_negotiation_list(frontier_t negotiation_frontie
         negotiation_element.y_coordinate = negotiation_frontier.y_coordinate;
         negotiation_element.id = negotiation_frontier.id;
 
-        negotiation_msg.frontier_element.push_back(negotiation_element); //FIXME
+        negotiation_msg.frontier_element.push_back(negotiation_element); // FIXME
     }
-      
+
     sendToMulticast("mc_",negotiation_msg, "negotiation_list");
-  
-    first_negotiation_run = false; 
+
+    first_negotiation_run = false;
+    return true;
 }
 
 
@@ -1483,24 +1536,24 @@ bool ExplorationPlanner::sendToMulticast(std::string multi_cast_group, adhoc_com
 {
 //    ROS_INFO("SENDING frontier id: %ld    detected_by: %ld", frontier_to_send.id ,frontier_to_send.detected_by_robot);
     adhoc_communication::SendExpFrontier service_frontier; // create request of type any+
-    
+
     std::stringstream robot_number;
     robot_number << robot_name;
     std::string prefix = "robot_";
-    std::string robo_name = prefix.append(robot_number.str());   
-    
+    std::string robo_name = prefix.append(robot_number.str());
+
     if(robot_prefix_empty_param == true)
     {
         robo_name = robot_str;
 //        robo_name = lookupRobotName(robot_name);
     }
-    
-	std::string destination_name = mc_group; //for multicast
+
+    std::string destination_name = mc_group; //for multicast
 //	std::string destination_name = multi_cast_group + robo_name; //for multicast
 //  std::string destination_name = robo_name; // unicast
-    
+
     ROS_INFO("sending to multicast group '%s' on topic: '%s'",destination_name.c_str(), topic.c_str());
-    service_frontier.request.dst_robot = destination_name; 
+    service_frontier.request.dst_robot = destination_name;
     service_frontier.request.frontier = frontier_to_send;
     service_frontier.request.topic = topic;
 
@@ -1517,7 +1570,7 @@ bool ExplorationPlanner::sendToMulticast(std::string multi_cast_group, adhoc_com
             {
                 ROS_DEBUG("Failed to send to multicast group %s!",destination_name.c_str());
                 return false;
-            }                  
+            }
     }
     else
     {
@@ -1530,24 +1583,24 @@ bool ExplorationPlanner::sendToMulticast(std::string multi_cast_group, adhoc_com
 bool ExplorationPlanner::sendToMulticastAuction(std::string multi_cast_group, adhoc_communication::ExpAuction auction_to_send, std::string topic)
 {
     adhoc_communication::SendExpAuction service_auction; // create request of type any+
-    
+
     std::stringstream robot_number;
     robot_number << robot_name;
     std::string prefix = "robot_";
-    std::string robo_name = prefix.append(robot_number.str());    
-      
+    std::string robo_name = prefix.append(robot_number.str());
+
     if(robot_prefix_empty_param == true)
     {
 //        robo_name = lookupRobotName(robot_name);
         robo_name = robot_str;
     }
-    
+
     std::string destination_name = mc_group; //for unified multicast
 //    std::string destination_name = multi_cast_group + robo_name; //for multicast
 //    std::string destination_name = robo_name; // unicast
-    
+
     ROS_INFO("sending auction to multicast group '%s' on topic '%s'",destination_name.c_str(), topic.c_str());
-    service_auction.request.dst_robot = destination_name; 
+    service_auction.request.dst_robot = destination_name;
     service_auction.request.auction = auction_to_send;
     service_auction.request.topic = topic;
 
@@ -1564,7 +1617,7 @@ bool ExplorationPlanner::sendToMulticastAuction(std::string multi_cast_group, ad
             {
                 ROS_WARN("Failed to send auction to mutlicast group %s!",destination_name.c_str());
                 return false;
-            }                  
+            }
     }
     else
     {
@@ -1574,12 +1627,12 @@ bool ExplorationPlanner::sendToMulticastAuction(std::string multi_cast_group, ad
 }
 
 void ExplorationPlanner::negotiationCallback(const adhoc_communication::ExpFrontier::ConstPtr& msg)
-{  
+{
 //        ROS_ERROR("Negotiation List!!!");
-        
+
         bool entry_found = false;
-        
-        adhoc_communication::ExpFrontierElement frontier_element; 
+
+        adhoc_communication::ExpFrontierElement frontier_element;
         for(int j = 0; j < msg.get()->frontier_element.size(); j++)
         {
             frontier_element = msg.get()->frontier_element.at(j);
@@ -1589,16 +1642,16 @@ void ExplorationPlanner::negotiationCallback(const adhoc_communication::ExpFront
                 {
                     if(negotiation_list.at(i).id == frontier_element.id && negotiation_list.at(i).detected_by_robot_str.compare(frontier_element.detected_by_robot_str) == 0)
                     {
-                        entry_found = true;       
-                    }  
+                        entry_found = true;
+                    }
                 }else
                 {
                     if(negotiation_list.at(i).id == frontier_element.id)
                     {
-                        entry_found = true;       
-                    }  
+                        entry_found = true;
+                    }
                 }
-                
+
             }
             if(entry_found == false)
             {
@@ -1610,7 +1663,7 @@ void ExplorationPlanner::negotiationCallback(const adhoc_communication::ExpFront
                 negotiation_frontier.y_coordinate = frontier_element.y_coordinate;
 
                 store_negotiation_mutex.lock();
-                negotiation_list.push_back(negotiation_frontier); 
+                negotiation_list.push_back(negotiation_frontier);
                 store_negotiation_mutex.unlock();
             }
         }
@@ -1620,18 +1673,18 @@ void ExplorationPlanner::negotiationCallback(const adhoc_communication::ExpFront
 //void ExplorationPlanner::auctionStatusCallback(const adhoc_communication::AuctionStatus::ConstPtr& msg)
 //{
 //    ROS_INFO("Calling AuctionStatusCallback");
-//    
+//
 //    auction_start = msg.get()->start_auction;
 //    auction_finished = msg.get()->auction_finished;
 //    adhoc_communication::Cluster occupied_ids;
 //    std::vector<int> requested_cluster_ids;
-//    
+//
 //    /*
 //     * Visualizing the received message
 //     */
 ////    for(int i = 0; i < msg.get()->requested_clusters.size(); i++)
 ////    {
-////        adhoc_communication::Cluster cluster_req; 
+////        adhoc_communication::Cluster cluster_req;
 ////        cluster_req = msg.get()->requested_clusters.at(i);
 ////        ROS_INFO("------------------- RECEIVED REQUEST %d ----------------------", i);
 ////        std::string requested_clusters;
@@ -1643,32 +1696,32 @@ void ExplorationPlanner::negotiationCallback(const adhoc_communication::ExpFront
 ////        ROS_INFO("Received auction with auction number: %d", msg.get()->auction_id);
 ////        ROS_INFO("Received requested ids: %s", requested_clusters.c_str());
 ////    }
-//    
+//
 //    /*
 //     * Cluster all available frontiers to be able to compare clusters
 //     * with other robots
 //     */
 //    clusterFrontiers();
-//    
+//
 //    if(msg.get()->occupied_ids.size() > 0 || msg.get()->requested_clusters.size() > 0)
 //    {
 //        for(int i = 0; i < msg.get()->occupied_ids.size(); i++)
 //        {
 //            occupied_ids.ids_contained.push_back(msg.get()->occupied_ids.at(i));
 //        }
-//        int occupied_cluster_id = checkClustersID(occupied_ids);     
+//        int occupied_cluster_id = checkClustersID(occupied_ids);
 //        if(occupied_cluster_id >=0)
 //        {
 //            already_used_ids.push_back(occupied_cluster_id);
-//        }      
+//        }
 ////        ROS_INFO("Requested cluster size: %lu", msg.get()->requested_clusters.size());
 //        for(int i = 0; i < msg.get()->requested_clusters.size(); i++)
 //        {
-//            adhoc_communication::Cluster requested_cluster,requested_ids; 
-//            
+//            adhoc_communication::Cluster requested_cluster,requested_ids;
+//
 //            requested_cluster = msg.get()->requested_clusters.at(i);
 ////            ROS_INFO("IDS_contained: %lu",requested_cluster.ids_contained.size());
-//            
+//
 ////            for(int j = 0; j < requested_cluster.ids_contained.size(); j++)
 ////            {
 //////                ROS_INFO("received ids: %d", requested_cluster.ids_contained.at(j));
@@ -1676,10 +1729,10 @@ void ExplorationPlanner::negotiationCallback(const adhoc_communication::ExpFront
 ////            }
 ////            ROS_INFO("----------------------------------------------------------");
 //            requested_cluster_ids.push_back(checkClustersID(requested_cluster));
-//        }   
+//        }
 //    }
-//    
-//    
+//
+//
 //    if(auction_start == true)
 //    {
 //        start_thr_auction = true;
@@ -1688,7 +1741,7 @@ void ExplorationPlanner::negotiationCallback(const adhoc_communication::ExpFront
 //}
 
 bool ExplorationPlanner::respondToAuction(std::vector<requested_cluster_t> requested_cluster_ids, int auction_id_number)
-{   
+{
 //    ros::Rate r(1);
 //    while(ros::ok())
 //    {
@@ -1696,169 +1749,169 @@ bool ExplorationPlanner::respondToAuction(std::vector<requested_cluster_t> reque
 ////        while(start_thr_auction == false);
 //        if(start_thr_auction == true)
 //        {
-            ROS_INFO("Respond to auction");
-            adhoc_communication::ExpAuction auction_msgs;
-            
-            for(int i = 0; i < requested_cluster_ids.size(); i++)
-            {
-                ROS_INFO("Responding to cluster ids: %d", requested_cluster_ids.at(i).own_cluster_id);
-            }
+    ROS_INFO("Respond to auction");
+    adhoc_communication::ExpAuction auction_msgs;
 
-            for(int n = 0; n < requested_cluster_ids.size(); n++)
+    for (int i = 0; i < requested_cluster_ids.size(); i++)
+    {
+        ROS_INFO("Responding to cluster ids: %d", requested_cluster_ids.at(i).own_cluster_id);
+    }
+
+    for (int n = 0; n < requested_cluster_ids.size(); n++)
+    {
+        cluster_mutex.lock();
+        for (int i = 0; i < clusters.size(); i++)
+        {
+            if (clusters.at(i).id == requested_cluster_ids.at(n).own_cluster_id)
             {
-                cluster_mutex.lock();
-                for(int i = 0; i < clusters.size(); i++)
+                adhoc_communication::ExpCluster cluster_msg;
+                adhoc_communication::ExpClusterElement cluster_element_msg;
+                for (int j = 0; j < requested_cluster_ids.at(n).requested_ids.size(); j++)
                 {
-                    if(clusters.at(i).id == requested_cluster_ids.at(n).own_cluster_id)
+                    if(robot_prefix_empty_param == true)
                     {
-                        adhoc_communication::ExpCluster cluster_msg;
-                        adhoc_communication::ExpClusterElement cluster_element_msg;
-                        for(int j = 0; j < requested_cluster_ids.at(n).requested_ids.size(); j++)
-                        {
-                            if(robot_prefix_empty_param == true)
-                            {
-                                cluster_element_msg.id = requested_cluster_ids.at(n).requested_ids.at(j).id;
-                                cluster_element_msg.detected_by_robot_str = requested_cluster_ids.at(n).requested_ids.at(j).robot_str;
-                            }else
-                            {
-                                cluster_element_msg.id = requested_cluster_ids.at(n).requested_ids.at(j).id;
-                            }
-                            cluster_msg.ids_contained.push_back(cluster_element_msg);
-                        }
-//                        ROS_INFO("Calculate the auction BID");
-                        cluster_msg.bid = calculateAuctionBID(clusters.at(i).id, trajectory_strategy);                       
-                        auction_msgs.available_clusters.push_back(cluster_msg);
-                        break;
+                        cluster_element_msg.id = requested_cluster_ids.at(n).requested_ids.at(j).id;
+                        cluster_element_msg.detected_by_robot_str = requested_cluster_ids.at(n).requested_ids.at(j).robot_str;
                     }
+                    else
+                    {
+                        cluster_element_msg.id = requested_cluster_ids.at(n).requested_ids.at(j).id;
+                    }
+                    cluster_msg.ids_contained.push_back(cluster_element_msg);
                 }
-                cluster_mutex.unlock();
+                // ROS_INFO("Calculate the auction BID");
+                cluster_msg.bid = calculateAuctionBID(clusters.at(i).id, trajectory_strategy);
+                auction_msgs.available_clusters.push_back(cluster_msg);
+                break;
             }
+        }
+        cluster_mutex.unlock();
+    }
 
-            /*
-             * Visualize the auction message to send
-             */
-//            for(int i = 0; i < auction_msgs.available_clusters.size(); i++)
-//            {
-//                adhoc_communication::Cluster cluster_msg_check;
-//                cluster_msg_check = auction_msgs.available_clusters.at(i);
-//                ROS_INFO("Robot %d sending BID: %f cluster elements: %lu", robot_name, cluster_msg_check.bid, cluster_msg_check.ids_contained.size());
-//            }
-            
-            ROS_INFO("Robot %d publishes auction bids for all clusters", robot_name);
-            
-//            /* FIXME */
-//            if(auction_msgs.available_clusters.size() == 0)
-//            {
-//                adhoc_communication::Cluster cluster_msg;
-//                cluster_msg.bid = -1;
-//                auction_msgs.available_clusters.push_back(cluster_msg);
-//            }
-//            
-            
-            auction_msgs.auction_status_message = false;
-            auction_msgs.auction_id = auction_id_number; 
-            
-            std::stringstream ss;
-            ss << robot_name; 
-            std::string prefix = "";
-            std::string robo_name = prefix.append(ss.str());  
-            
-            auction_msgs.robot_name = robo_name;
-    
-//            if(first_run == true)
-//            {
-//                pub_auctioning_first.publish(auction_msgs);
-//            }else
-//            {
-                sendToMulticastAuction("mc_", auction_msgs, "auction");
-//            }
-            
-            start_thr_auction = false; 
-//        }
-//    }
+    /*
+     * Visualize the auction message to send
+     */
+    // for (int i = 0; i < auction_msgs.available_clusters.size(); i++)
+    // {
+    //    adhoc_communication::Cluster cluster_msg_check;
+    //    cluster_msg_check = auction_msgs.available_clusters.at(i);
+    //    ROS_INFO("Robot %d sending BID: %f cluster elements: %lu",
+    //             robot_name,
+    //             cluster_msg_check.bid,
+    //             cluster_msg_check.ids_contained.size());
+    // }
+    ROS_INFO("Robot %d publishes auction bids for all clusters", robot_name);
+    // /* FIXME */
+    // if (auction_msgs.available_clusters.size() == 0)
+    // {
+    //     adhoc_communication::Cluster cluster_msg;
+    //     cluster_msg.bid = -1;
+    //     auction_msgs.available_clusters.push_back(cluster_msg);
+    // }
+    auction_msgs.auction_status_message = false;
+    auction_msgs.auction_id = auction_id_number;
+    std::stringstream ss;
+    ss << robot_name;
+    std::string prefix = "";
+    std::string robo_name = prefix.append(ss.str());
+
+    auction_msgs.robot_name = robo_name;
+
+    // if (first_run == true)
+    // {
+    //     pub_auctioning_first.publish(auction_msgs);
+    // }
+    // else
+    // {
+    sendToMulticastAuction("mc_", auction_msgs, "auction");
+    // }
+
+    start_thr_auction = false;
+    //  }
+    // }
+    return true;
 }
-
 
 int ExplorationPlanner::calculateAuctionBID(int cluster_number, std::string strategy)
 {
 //    ROS_INFO("Robot %d  calculates bid for cluster_number %d", robot_name, cluster_number);
-    int auction_bid = 0; 
+    int auction_bid = 0;
     int cluster_vector_position = -1;
-    bool cluster_could_be_found = false; 
-    
+    bool cluster_could_be_found = false;
+
     if(clusters.size() > 0)
-    {                   
+    {
         for (int i = 0; i < clusters.size(); i++)
         {
             if(clusters.at(i).id == cluster_number)
             {
 //                if(clusters.at(i).cluster_element.size() > 0)
 //                {
-                    cluster_vector_position = i; 
+                    cluster_vector_position = i;
                     cluster_could_be_found = true;
                     break;
 //                }else
 //                {
-//                    ROS_ERROR("Cluster found but empty, therefore do not calculate LOCAL BID");                   
+//                    ROS_ERROR("Cluster found but empty, therefore do not calculate LOCAL BID");
 //                    return(-1);
 //                }
             }
-        }                      
+        }
     }
     if(cluster_could_be_found == false)
-    {     
+    {
         /*
          * Cluster could not be found, set it to a high value like 100
          */
         ROS_WARN("Cluster could not be found");
-        return(-1); 
+        return(-1);
     }
-    
+
     if (!costmap_global_ros_->getRobotPose(robotPose))
-    {       
+    {
             ROS_ERROR("Failed to get RobotPose");
     }
-    
+
     int distance = -1;
     for(int i = 0; i < clusters.at(cluster_vector_position).cluster_element.size(); i++)
     {
-        
+
         if(strategy == "trajectory")
         {
                distance = check_trajectory_plan(clusters.at(cluster_vector_position).cluster_element.at(i).x_coordinate, clusters.at(cluster_vector_position).cluster_element.at(i).y_coordinate);
 //               distance = estimate_trajectory_plan(robotPose.getOrigin().getX(), robotPose.getOrigin().getY(), clusters.at(cluster_vector_position).cluster_element.at(i).x_coordinate, clusters.at(cluster_vector_position).cluster_element.at(i).y_coordinate);
-      
+
 //               ROS_INFO("Distance for cluster %d: %d",clusters.at(cluster_vector_position).id, distance);
-       
+
         }else if(strategy == "euclidean")
         {
             double x = clusters.at(cluster_vector_position).cluster_element.at(i).x_coordinate - robotPose.getOrigin().getX();
-            double y = clusters.at(cluster_vector_position).cluster_element.at(i).y_coordinate - robotPose.getOrigin().getY();        
+            double y = clusters.at(cluster_vector_position).cluster_element.at(i).y_coordinate - robotPose.getOrigin().getY();
             distance = x * x + y * y;
-            return distance; 
+            return distance;
         }
-               
+
         if(distance > 0)
         {
             double x = clusters.at(cluster_vector_position).cluster_element.at(i).x_coordinate - robotPose.getOrigin().getX();
-            double y = clusters.at(cluster_vector_position).cluster_element.at(i).y_coordinate - robotPose.getOrigin().getY();        
+            double y = clusters.at(cluster_vector_position).cluster_element.at(i).y_coordinate - robotPose.getOrigin().getY();
             double euclidean_distance = x * x + y * y;
-           
+
             /*
-             * Check if the distance calculation is plausible. 
-             * The euclidean distance to this point need to be smaller then 
+             * Check if the distance calculation is plausible.
+             * The euclidean distance to this point need to be smaller then
              * the simulated trajectory path. If this stattement is not valid
-             * the trajectory calculation has failed. 
+             * the trajectory calculation has failed.
              */
 //            ROS_INFO("Euclidean distance: %f   trajectory_path: %f", sqrt(euclidean_distance), distance* costmap_ros_->getCostmap()->getResolution());
-            if (distance * costmap_ros_->getCostmap()->getResolution() <= sqrt(euclidean_distance)*0.95) 
+            if (distance * costmap_ros_->getCostmap()->getResolution() <= sqrt(euclidean_distance)*0.95)
             {
                 ROS_WARN("Euclidean distance smaller then trajectory distance to LOCAL CLUSTER!!!");
 //                return(-1);
             }else
             {
                 return distance;
-            }           
+            }
         }
     }
     if(distance == -1)
@@ -1874,11 +1927,11 @@ void ExplorationPlanner::positionCallback(const adhoc_communication::MmListOfPoi
 {
     ROS_DEBUG("Position Callback !!!!!");
     position_mutex.lock();
-    
+
     other_robots_positions.positions.clear();
     ROS_INFO("positions size: %zu", msg.get()->positions.size());
     for(int i = 0; i < msg.get()->positions.size(); i++)
-    {    
+    {
         other_robots_positions.positions.push_back(msg.get()->positions.at(i));
     }
     position_mutex.unlock();
@@ -1890,13 +1943,13 @@ void ExplorationPlanner::auctionCallback(const adhoc_communication::ExpAuction::
     auction_running = true;
     //ROS_ERROR("CALLING AUCTION CALLBACK!!!!!!!!!!!!");
     int robots_int_name;
-    
-    bool same_robot = false; 
+
+    bool same_robot = false;
     if(robot_prefix_empty_param == true)
     {
         if(robot_str.compare(msg.get()->robot_name.c_str()) == 0)
         {
-            same_robot = true; 
+            same_robot = true;
         }
     }else
     {
@@ -1904,48 +1957,48 @@ void ExplorationPlanner::auctionCallback(const adhoc_communication::ExpAuction::
         ROS_INFO("Robot name: %d      int_name: %d",robot_name, robots_int_name);
         if(robots_int_name == robot_name)
         {
-            same_robot = true; 
+            same_robot = true;
         }
     }
-  
+
     if(same_robot == false)
     {
         /*
         * Cluster all available frontiers to be able to compare clusters
         * with other robots
         */
-       
+
         /*
          * TODO
-         * Check if following code is necessary or if simple navigation needs to 
-         * periodically update the frontiers in the frontier thread.  
+         * Check if following code is necessary or if simple navigation needs to
+         * periodically update the frontiers in the frontier thread.
          */
         transformToOwnCoordinates_frontiers();
         transformToOwnCoordinates_visited_frontiers();
-        
-        clearVisitedFrontiers();                       
+
+        clearVisitedFrontiers();
         clearUnreachableFrontiers();
-        clearSeenFrontiers(costmap_global_ros_);       
-        
+        clearSeenFrontiers(costmap_global_ros_);
+
         clearVisitedAndSeenFrontiersFromClusters();
         clusterFrontiers();
-        
-     
+
+
 //        visualize_Cluster_Cells();
-        
+
         if(msg.get()->auction_status_message == true)
-        { 
+        {
             ROS_INFO("Calling Auction Status");
-            
+
             /*
              * Visualize requested ids
              */
-           
+
             for(int i = 0; i < msg.get()->requested_clusters.size(); i++)
-            {  
-                adhoc_communication::ExpCluster cluster_req; 
+            {
+                adhoc_communication::ExpCluster cluster_req;
                 cluster_req = msg.get()->requested_clusters.at(i);
-                std::string requested_clusters; 
+                std::string requested_clusters;
                 for(int j = 0; j < cluster_req.ids_contained.size(); j++)
                 {
                     if(j >= 6)
@@ -1957,35 +2010,35 @@ void ExplorationPlanner::auctionCallback(const adhoc_communication::ExpAuction::
                 }
                 ROS_INFO("Requested ids: %s from robot: %s", requested_clusters.c_str(), msg.get()->robot_name.c_str());
             }
-            
-            
+
+
 
             auction_start = msg.get()->start_auction;
             auction_finished = msg.get()->auction_finished;
             adhoc_communication::ExpCluster occupied_ids;
             std::vector<requested_cluster_t> requested_cluster_ids;
 
-            
+
             /*
-             * Grep all occupied ids and try to convert them into clusters in own 
+             * Grep all occupied ids and try to convert them into clusters in own
              * coordinate system. This ensures that all robots in the system know
              * which clusters had been occupied by others and do not select them
-             * twice. 
+             * twice.
              */
             if(msg.get()->occupied_ids.size() > 0 || msg.get()->requested_clusters.size() > 0)
             {
                 for(int i = 0; i < msg.get()->occupied_ids.size(); i++)
                 {
-                    adhoc_communication::ExpClusterElement cluster_element; 
-                    
-                    cluster_element.id = msg.get()->occupied_ids.at(i).id; 
+                    adhoc_communication::ExpClusterElement cluster_element;
+
+                    cluster_element.id = msg.get()->occupied_ids.at(i).id;
                     cluster_element.detected_by_robot_str = msg.get()->occupied_ids.at(i).detected_by_robot_str;
-                    
+
                     occupied_ids.ids_contained.push_back(cluster_element);
                 }
-                int occupied_cluster_id = checkClustersID(occupied_ids);   
+                int occupied_cluster_id = checkClustersID(occupied_ids);
                 ROS_INFO("Check occupied cluster to be the same. %d", occupied_cluster_id);
-                
+
                 if(occupied_cluster_id >=0)
                 {
                     ROS_INFO("Adding occupied cluster: %d", occupied_cluster_id);
@@ -1998,7 +2051,7 @@ void ExplorationPlanner::auctionCallback(const adhoc_communication::ExpAuction::
                 }
                 /*
                  * Now read from unrecognized cluster vector and try to convert
-                 * these ids to a valid cluster to know which had already been 
+                 * these ids to a valid cluster to know which had already been
                  * occupied.
                  */
                 for(int i = 0; i < unrecognized_occupied_clusters.size(); i++)
@@ -2009,47 +2062,47 @@ void ExplorationPlanner::auctionCallback(const adhoc_communication::ExpAuction::
                         ROS_INFO("Unrecognized cluster: %d converted", unrecognized_occupied_cluster_id);
                         already_used_ids.push_back(unrecognized_occupied_cluster_id);
                         unrecognized_occupied_clusters.erase(unrecognized_occupied_clusters.begin() + i);
-                        
+
                         if(i > 0)
                             i--;
                     }
                 }
-                
-                
+
+
                 /*
-                 * Grep the requested clusters to know which ones to answer to. 
+                 * Grep the requested clusters to know which ones to answer to.
                  */
                 for(int i = 0; i < msg.get()->requested_clusters.size(); i++)
-                {    
+                {
                     adhoc_communication::ExpCluster requested_cluster;
                     requested_cluster = msg.get()->requested_clusters.at(i);
-                    
+
                     int check_cluster_id = checkClustersID(requested_cluster);
                     if(check_cluster_id >= 0)
                     {
-                        requested_cluster_t new_cluster_request; 
+                        requested_cluster_t new_cluster_request;
                         for(int j = 0; j < requested_cluster.ids_contained.size(); j++)
                         {
                             transform_point_t cluster_element_point;
                             if(robot_prefix_empty_param == true)
                             {
                                 cluster_element_point.id = requested_cluster.ids_contained.at(j).id;
-                                cluster_element_point.robot_str = requested_cluster.ids_contained.at(j).detected_by_robot_str;                    
+                                cluster_element_point.robot_str = requested_cluster.ids_contained.at(j).detected_by_robot_str;
                             }else
                             {
-                                cluster_element_point.id = requested_cluster.ids_contained.at(j).id;                                                          
+                                cluster_element_point.id = requested_cluster.ids_contained.at(j).id;
                             }
-                            
+
                             new_cluster_request.requested_ids.push_back(cluster_element_point);
                         }
-                        new_cluster_request.own_cluster_id = check_cluster_id; 
-                        
+                        new_cluster_request.own_cluster_id = check_cluster_id;
+
                         requested_cluster_ids.push_back(new_cluster_request);
                     }else
                     {
                         ROS_WARN("No Matching Cluster Detected");
                     }
-                }   
+                }
             }
 
 
@@ -2061,26 +2114,26 @@ void ExplorationPlanner::auctionCallback(const adhoc_communication::ExpAuction::
 
         }else if(msg.get()->auction_status_message == false)
         {
-            bool continue_auction = false; 
+            bool continue_auction = false;
             if(robot_prefix_empty_param == true)
             {
                 if(msg.get()->auction_id == auction_id_number)
                 {
-                    continue_auction = true; 
+                    continue_auction = true;
                 }
             }else
             {
                 if(msg.get()->auction_id == 10000*robot_name + auction_id_number)
                 {
-                    continue_auction = true; 
+                    continue_auction = true;
                 }
             }
-              
-            
+
+
             if(continue_auction == true)
             {
     //            ROS_INFO("auction_id: %d       local_id: %d", msg.get()->auction_id, 10000*robot_name + auction_id_number);
-                bool robot_already_answered = false; 
+                bool robot_already_answered = false;
 
                 for(int i = 0; i < robots_already_responded.size(); i++)
                 {
@@ -2089,7 +2142,7 @@ void ExplorationPlanner::auctionCallback(const adhoc_communication::ExpAuction::
                         if(msg.get()->robot_name.compare(robots_already_responded.at(i).robot_str) == 0 && msg.get()->auction_id == robots_already_responded.at(i).auction_number)
                         {
                             ROS_WARN("Same msg already received!!!");
-                            robot_already_answered = true; 
+                            robot_already_answered = true;
                             break;
                         }
                     }else
@@ -2098,14 +2151,14 @@ void ExplorationPlanner::auctionCallback(const adhoc_communication::ExpAuction::
                         if(robots_int_name == robots_already_responded.at(i).robot_number && msg.get()->auction_id == robots_already_responded.at(i).auction_number)
                         {
                             ROS_WARN("Same msg already received!!!");
-                            robot_already_answered = true; 
+                            robot_already_answered = true;
                             break;
                         }
                     }
                 }
 
                 /*
-                 * Only proceed if the robot has not answered before. 
+                 * Only proceed if the robot has not answered before.
                  */
                 if(robot_already_answered == false)
                 {
@@ -2114,9 +2167,9 @@ void ExplorationPlanner::auctionCallback(const adhoc_communication::ExpAuction::
                         ROS_INFO("Auction from robot %s received", msg.get()->robot_name.c_str());
                     }else
                     {
-                        ROS_INFO("Auction from robot %d received", robot_name);          
+                        ROS_INFO("Auction from robot %d received", robot_name);
                     }
-                    auction_pair_t auction_pair;  
+                    auction_pair_t auction_pair;
                     auction_element_t auction_elements;
 
                     int has_cluster_id = -1;
@@ -2126,7 +2179,7 @@ void ExplorationPlanner::auctionCallback(const adhoc_communication::ExpAuction::
                      */
                     for(int i = 0; i < msg.get()->available_clusters.size(); i++)
                     {
-                        adhoc_communication::ExpCluster cluster_req; 
+                        adhoc_communication::ExpCluster cluster_req;
                         cluster_req = msg.get()->available_clusters.at(i);
                         ROS_INFO("---------------------- %d ----------------------------", i);
                         std::string requested_clusters;
@@ -2165,21 +2218,21 @@ void ExplorationPlanner::auctionCallback(const adhoc_communication::ExpAuction::
                         }
                     }
                 //    ROS_INFO("Robot %d received all bids for all clusters", robot_name);
-                    auction_elements.robot_id = robots_int_name;                   
+                    auction_elements.robot_id = robots_int_name;
                     auction_elements.detected_by_robot_str = msg.get()->robot_name;
-                    
+
                     auction_mutex.lock();
                     auction.push_back(auction_elements);
                     auction_mutex.unlock();
 
                     /*
-                     * A BID is received from one robot. Remember the robot who send the 
-                     * bid for a special auction id! 
-                     */      
-    //                if(msg.get()->auction_id == 10000*robot_name + auction_id_number)   
+                     * A BID is received from one robot. Remember the robot who send the
+                     * bid for a special auction id!
+                     */
+    //                if(msg.get()->auction_id == 10000*robot_name + auction_id_number)
     //                {
                         number_of_auction_bids_received++;
-                        responded_t auction_response; 
+                        responded_t auction_response;
                         auction_response.auction_number = msg.get()->auction_id;
                         auction_response.robot_number = robots_int_name;
                         if(robot_prefix_empty_param == true)
@@ -2200,28 +2253,28 @@ void ExplorationPlanner::auctionCallback(const adhoc_communication::ExpAuction::
 
 
 bool sortCompareElements(const ExplorationPlanner::compare_pair_t &lhs, const ExplorationPlanner::compare_pair_t &rhs)
-{       
-        return lhs.identical_ids > rhs.identical_ids;    
+{
+        return lhs.identical_ids > rhs.identical_ids;
 }
 
 int ExplorationPlanner::checkClustersID(adhoc_communication::ExpCluster cluster_to_check)
 {
 //    ROS_INFO("Check for cluster id");
-      std::vector<compare_pair_t> compare_clusters;  
-        
+      std::vector<compare_pair_t> compare_clusters;
+
 //        ROS_INFO("------------------- Checking ----------------------");
         std::string requested_clusters;
-        
+
 //        for(int j = 0; j < cluster_to_check.ids_contained.size(); j++)
 //        {
 //            requested_clusters.append(NumberToString((int)cluster_to_check.ids_contained.at(j)));
 //            requested_clusters.append(", ");
 //        }
 //        ROS_INFO("%s", requested_clusters.c_str());
-    
-    
-    
-    
+
+
+
+
     for(int j = 0; j < clusters.size(); j++)
     {
         double same_id_found = 0;
@@ -2249,13 +2302,13 @@ int ExplorationPlanner::checkClustersID(adhoc_communication::ExpCluster cluster_
                         same_id_found++;
                     }
                 }
-            }                  
+            }
         }
         if(same_id_found > clusters.at(j).cluster_element.size() * 0.4)
         {
 //            ROS_INFO("CLUSTER ID FOUND: %d", clusters.at(j).id);
             return (clusters.at(j).id);
-        } 
+        }
         else
         {
 //            ROS_ERROR("NO MATCHING CLUSTER FOUND!!!");
@@ -2263,21 +2316,21 @@ int ExplorationPlanner::checkClustersID(adhoc_communication::ExpCluster cluster_
 //        ROS_INFO("---------------------------------------------------");
 
 //        ROS_INFO("j: %d   cluster_id: %d", j, clusters.at(j).id);
-//        compare_pair_t compare_pair; 
+//        compare_pair_t compare_pair;
 //        compare_pair.identical_ids = same_id_found;
 //        compare_pair.cluster_id = clusters.at(j).id;
 //        compare_clusters.push_back(compare_pair);
 //        ROS_INFO("Same IDs found: %f   elements*0.7: %f", same_id_found,clusters.at(j).cluster_element.size() * 0.7);
-        
-        
+
+
 //            if(same_id_found > clusters.at(j).cluster_element.size() * 0.8)
 //            {
-//                bool previously_detected = false; 
+//                bool previously_detected = false;
 //                for(int m = 0; m < id_previously_detected.size(); m++)
 //                {
 //                    if(clusters.at(j).id == id_previously_detected.at(m))
 //                    {
-//                        previously_detected = true; 
+//                        previously_detected = true;
 //                        break;
 //                    }
 //                }
@@ -2286,15 +2339,15 @@ int ExplorationPlanner::checkClustersID(adhoc_communication::ExpCluster cluster_
 //                    id_previously_detected.push_back(clusters.at(j).id);
 //                    return (clusters.at(j).id);
 //                }
-//            }           
+//            }
     }
-    
+
     /*
      * Sort compare_pairs and select the one with the highest similarity
      */
 //    if(compare_clusters.size() > 0)
 //    {
-//        
+//
 //        std::sort(compare_clusters.begin(), compare_clusters.end(), sortCompareElements);
 ////        for(int i = 0; i < compare_clusters.size(); i++)
 ////        {
@@ -2314,17 +2367,17 @@ int ExplorationPlanner::checkClustersID(adhoc_communication::ExpCluster cluster_
 //void ExplorationPlanner::controlCallback( const bla& msg)
 //{
 //    /* Check if manual control or automatic. If automatic, set simulation to false, otherwise set simulation to true in simple_navigation */
-//    
-//    SimpleNavigation.Simulation = true; 
+//
+//    SimpleNavigation.Simulation = true;
 //}
 
 
 
 void ExplorationPlanner::frontierCallback(const adhoc_communication::ExpFrontier::ConstPtr& msg)
-{  
-    
+{
+
 //    ROS_ERROR("FRONTIER RECEIVED!!!!!!!!!!!!!!!!!!!!!!!!");
-    adhoc_communication::ExpFrontierElement frontier_element; 
+    adhoc_communication::ExpFrontierElement frontier_element;
     for(int i = 0; i < msg.get()->frontier_element.size(); i++)
     {
         frontier_element = msg.get()->frontier_element.at(i);
@@ -2344,14 +2397,14 @@ void ExplorationPlanner::frontierCallback(const adhoc_communication::ExpFrontier
             else
             {
                 if(frontier_element.detected_by_robot == robot_name)
-                {          
+                {
                     result = false;
-                    break;      
+                    break;
                 }
                 else
                 {
                     if (frontier_element.id == frontiers.at(j).id)
-                    {  
+                    {
                         result = false;
                         break;
                     }
@@ -2360,7 +2413,7 @@ void ExplorationPlanner::frontierCallback(const adhoc_communication::ExpFrontier
         }
         if (result == true)
         {
-            
+
             if(robot_prefix_empty_param == true)
             {
                 ROS_DEBUG("Received New Frontier with ID: %" PRId64 "  Robot: %s", frontier_element.id, frontier_element.detected_by_robot_str.c_str());
@@ -2370,34 +2423,34 @@ void ExplorationPlanner::frontierCallback(const adhoc_communication::ExpFrontier
                 ROS_DEBUG("Received New Frontier of Robot %" PRId64 " with ID %" PRId64 "", frontier_element.detected_by_robot, frontier_element.id);
                 if(frontier_element.detected_by_robot != robot_name)
                 {
-                    storeFrontier(frontier_element.x_coordinate, frontier_element.y_coordinate, frontier_element.detected_by_robot, "", frontier_element.id); 
-                }   
+                    storeFrontier(frontier_element.x_coordinate, frontier_element.y_coordinate, frontier_element.detected_by_robot, "", frontier_element.id);
+                }
             }
         }
     }
-    
+
 }
 
 
 void ExplorationPlanner::visited_frontierCallback(const adhoc_communication::ExpFrontier::ConstPtr& msg)
-{       
-    adhoc_communication::ExpFrontierElement frontier_element; 
+{
+    adhoc_communication::ExpFrontierElement frontier_element;
     for(int i = 0; i < msg.get()->frontier_element.size(); i++)
     {
         frontier_element = msg.get()->frontier_element.at(i);
-        
+
         bool result = true;
         for (unsigned int j = 0; j < visited_frontiers.size(); j++)
         {
             if(frontier_element.detected_by_robot == robot_name)
-            {    
-                result = false;                 
-                break;                         
+            {
+                result = false;
+                break;
             }
             else
             {
                 if (frontier_element.id == visited_frontiers.at(j).id)
-                {  
+                {
                     result = false;
                     break;
                 }
@@ -2413,68 +2466,70 @@ void ExplorationPlanner::visited_frontierCallback(const adhoc_communication::Exp
             }else
             {
                 if(frontier_element.detected_by_robot != robot_name)
-                {    
-                    storeVisitedFrontier(frontier_element.x_coordinate, frontier_element.y_coordinate, frontier_element.detected_by_robot, "", frontier_element.id); 
-                }  
+                {
+                    storeVisitedFrontier(frontier_element.x_coordinate, frontier_element.y_coordinate, frontier_element.detected_by_robot, "", frontier_element.id);
+                }
             }
-        } 
+        }
     }
 }
 
 bool ExplorationPlanner::publish_frontier_list()
 {
-//    ROS_INFO("PUBLISHING FRONTIER LIST");
-    
+    // ROS_INFO("PUBLISHING FRONTIER LIST");
+
     publish_subscribe_mutex.lock();
-    
+
     adhoc_communication::ExpFrontier frontier_msg;
-    for(int i = 0; i<frontiers.size(); i++)
+    for (int i = 0; i<frontiers.size(); i++)
     {
         adhoc_communication::ExpFrontierElement frontier_element;
-                
+
         frontier_element.id = frontiers.at(i).id;
         frontier_element.detected_by_robot = frontiers.at(i).detected_by_robot;
         frontier_element.detected_by_robot_str = frontiers.at(i).detected_by_robot_str;
-        frontier_element.robot_home_position_x = frontiers.at(i).robot_home_x; 
+        frontier_element.robot_home_position_x = frontiers.at(i).robot_home_x;
         frontier_element.robot_home_position_y = frontiers.at(i).robot_home_y;
         frontier_element.x_coordinate = frontiers.at(i).x_coordinate;
         frontier_element.y_coordinate = frontiers.at(i).y_coordinate;
 
         frontier_msg.frontier_element.push_back(frontier_element);
     }
-    
-//    pub_frontiers.publish(frontier_msg);
+
+    // pub_frontiers.publish(frontier_msg);
     sendToMulticast("mc_",frontier_msg, "frontiers");
-   
+
     publish_subscribe_mutex.unlock();
+    return true;
 }
 
 bool ExplorationPlanner::publish_visited_frontier_list()
 {
-//    ROS_INFO("PUBLISHING VISITED FRONTIER LIST");
-    
+    // ROS_INFO("PUBLISHING VISITED FRONTIER LIST");
+
     publish_subscribe_mutex.lock();
-    
+
     adhoc_communication::ExpFrontier visited_frontier_msg;
-    
-    for(int i = 0; i<visited_frontiers.size(); i++)
+
+    for (int i = 0; i<visited_frontiers.size(); i++)
     {
         adhoc_communication::ExpFrontierElement visited_frontier_element;
-//        visited_frontier_element.id = frontiers.at(i).id;
+        // visited_frontier_element.id = frontiers.at(i).id;
         visited_frontier_element.detected_by_robot = visited_frontiers.at(i).detected_by_robot;
         visited_frontier_element.detected_by_robot_str = visited_frontiers.at(i).detected_by_robot_str;
-        visited_frontier_element.robot_home_position_x = visited_frontiers.at(i).robot_home_x; 
+        visited_frontier_element.robot_home_position_x = visited_frontiers.at(i).robot_home_x;
         visited_frontier_element.robot_home_position_y = visited_frontiers.at(i).robot_home_y;
         visited_frontier_element.x_coordinate = visited_frontiers.at(i).x_coordinate;
         visited_frontier_element.y_coordinate = visited_frontiers.at(i).y_coordinate;
-       
+
         visited_frontier_msg.frontier_element.push_back(visited_frontier_element);
     }
-   
-//    pub_visited_frontiers.publish(visited_frontier_msg);
+
+    // pub_visited_frontiers.publish(visited_frontier_msg);
     sendToMulticast("mc_",visited_frontier_msg, "visited_frontiers");
-    
+
     publish_subscribe_mutex.unlock();
+    return true;
 }
 
 /*
@@ -2489,13 +2544,13 @@ bool ExplorationPlanner::publish_visited_frontier_list()
 bool ExplorationPlanner::check_efficiency_of_goal(double x, double y) {
 
 //    ROS_INFO("Check efficiency");
-	double diff_home_x = visited_frontiers.at(0).x_coordinate - x;
-	double diff_home_y = visited_frontiers.at(0).y_coordinate - y;
-        
-	if (fabs(diff_home_x) <= MAX_DISTANCE && fabs(diff_home_y) <= MAX_DISTANCE) 
+    double diff_home_x = visited_frontiers.at(0).x_coordinate - x;
+    double diff_home_y = visited_frontiers.at(0).y_coordinate - y;
+
+    if (fabs(diff_home_x) <= MAX_DISTANCE && fabs(diff_home_y) <= MAX_DISTANCE)
         {
-		for (int i = 0; i < visited_frontiers.size(); i++)
-		{
+        for (int i = 0; i < visited_frontiers.size(); i++)
+        {
                     /*
                      * Calculate the distance between all previously seen goals and the new
                      * found frontier!!
@@ -2507,9 +2562,9 @@ bool ExplorationPlanner::check_efficiency_of_goal(double x, double y) {
                         ROS_DEBUG("x: %f  y: %f too close to visited at x: %f   y: %f   dif_x: %f   dif_y: %f", x, y, visited_frontiers.at(i).x_coordinate, visited_frontiers.at(i).y_coordinate, diff_x, diff_y);
                         return false;
                     }
-		}
+        }
                 for (int i = 0; i < unreachable_frontiers.size(); i++)
-		{
+        {
                     /*
                      * Calculate the distance between all previously seen goals and the new
                      * found frontier!!
@@ -2521,37 +2576,37 @@ bool ExplorationPlanner::check_efficiency_of_goal(double x, double y) {
                         ROS_DEBUG("x: %f  y: %f too close to unreachable at x: %f   y: %f   dif_x: %f   dif_y: %f", x, y, unreachable_frontiers.at(i).x_coordinate, unreachable_frontiers.at(i).y_coordinate, diff_x, diff_y);
                         return false;
                     }
-		}
-		return true;
-	}
-	else
-	{
+        }
+        return true;
+    }
+    else
+    {
             ROS_WARN("OUT OF HOME RANGE");
             return false;
-	}
+    }
 }
 
 void ExplorationPlanner::clearVisitedAndSeenFrontiersFromClusters()
 {
     ROS_INFO("Clear VisitedAndSeenFrontiers from Cluster");
     std::vector<int> goals_to_clear;
-    
-    
-    
+
+
+
     for(int i = 0; i < clusters.size(); i++)
     {
         for(int j = 0; j < clusters.at(i).cluster_element.size(); j++)
         {
-            /* Now iterate over all frontiers and check if cluster elements are 
+            /* Now iterate over all frontiers and check if cluster elements are
              * still available in the frontier vector
              */
-            bool cluster_still_valid = false; 
+            bool cluster_still_valid = false;
             for(int m = 0; m < frontiers.size(); m++)
             {
                 if(clusters.at(i).cluster_element.at(j).id == frontiers.at(m).id)
                 {
                     /*Cluster is still valid, do not clear it*/
-                    cluster_still_valid = true; 
+                    cluster_still_valid = true;
                     break;
                 }
             }
@@ -2559,11 +2614,11 @@ void ExplorationPlanner::clearVisitedAndSeenFrontiersFromClusters()
             {
                 clusters.at(i).cluster_element.erase(clusters.at(i).cluster_element.begin() +j);
                 if(j > 0)
-                   j--;                  
+                   j--;
             }
         }
     }
-    
+
     for(int i = 0; i < clusters.size(); i++)
     {
         if(clusters.at(i).cluster_element.size() <= 0)
@@ -2571,8 +2626,8 @@ void ExplorationPlanner::clearVisitedAndSeenFrontiersFromClusters()
             clusters.erase(clusters.begin() + i);
         }
     }
-    
-    
+
+
 //    if(visited_frontiers.size() > 1)
 //    {
 //        for (int i = 1; i < visited_frontiers.size(); i++)
@@ -2585,7 +2640,7 @@ void ExplorationPlanner::clearVisitedAndSeenFrontiersFromClusters()
 //                    double diff_x = visited_frontiers.at(i).x_coordinate - clusters.at(j).cluster_element.at(n).x_coordinate;
 //                    double diff_y = visited_frontiers.at(i).y_coordinate - clusters.at(j).cluster_element.at(n).y_coordinate;
 //
-//                    if (fabs(diff_x) <= MAX_GOAL_RANGE && fabs(diff_y) <= MAX_GOAL_RANGE) 
+//                    if (fabs(diff_x) <= MAX_GOAL_RANGE && fabs(diff_y) <= MAX_GOAL_RANGE)
 //                    {
 //                        ROS_DEBUG("Erasing visited frontier %d from cluster", clusters.at(j).cluster_element.at(n).id);
 //                        clusters.at(j).cluster_element.erase(clusters.at(j).cluster_element.begin()+n);
@@ -2617,7 +2672,7 @@ void ExplorationPlanner::clearVisitedAndSeenFrontiersFromClusters()
 //                    double diff_x = seen_frontier_list.at(i).x_coordinate - clusters.at(j).cluster_element.at(n).x_coordinate;
 //                    double diff_y = seen_frontier_list.at(i).y_coordinate - clusters.at(j).cluster_element.at(n).y_coordinate;
 //
-//                    if (fabs(diff_x) <= MAX_GOAL_RANGE*2 && fabs(diff_y) <= MAX_GOAL_RANGE*2) 
+//                    if (fabs(diff_x) <= MAX_GOAL_RANGE*2 && fabs(diff_y) <= MAX_GOAL_RANGE*2)
 //                    {
 //                        ROS_DEBUG("Erasing seen frontier %d from cluster", clusters.at(j).cluster_element.at(n).id);
 //                        clusters.at(j).cluster_element.erase(clusters.at(j).cluster_element.begin()+n);
@@ -2643,21 +2698,21 @@ void ExplorationPlanner::clearVisitedAndSeenFrontiersFromClusters()
 void ExplorationPlanner::clearVisitedFrontiers()
 {
 //    ROS_INFO("Clear Visited");
-    
+
     /* visited_frontier.at(0) is the Home point. Do not compare
      * with this point. Otherwise this algorithm deletes it, a new
      * frontier close to the home point is found which is then again
      * deleted since it is to close to the home point. This would not
-     * have any impact on the exploration, but in simulation mode 
-     * (simulation = true) the frontier_ID is steadily up counted. 
-     * This is not necessary! 
+     * have any impact on the exploration, but in simulation mode
+     * (simulation = true) the frontier_ID is steadily up counted.
+     * This is not necessary!
      */
     std::vector<int> goals_to_clear;
-    
+
     for (int i = 1; i < visited_frontiers.size(); i++)
     {
         for (int j = 0; j < frontiers.size(); j++)
-	{
+    {
             double diff_x = visited_frontiers.at(i).x_coordinate - frontiers.at(j).x_coordinate;
             double diff_y = visited_frontiers.at(i).y_coordinate - frontiers.at(j).y_coordinate;
 
@@ -2682,31 +2737,31 @@ void ExplorationPlanner::clearVisitedFrontiers()
             }
         }
     }
-    
+
 //    for(int i= 0; i< goals_to_clear.size(); i++)
 //    {
-//        removeStoredFrontier(goals_to_clear.at(i), goals_to_clear.); 
-//    }   
+//        removeStoredFrontier(goals_to_clear.at(i), goals_to_clear.);
+//    }
 }
 
 void ExplorationPlanner::clearUnreachableFrontiers()
 {
 //    ROS_INFO("Clear UNREACHABLE");
-    
+
     /* visited_frontier.at(0) is the Home point. Do not compare
      * with this point. Otherwise this algorithm deletes it, a new
      * frontier close to the home point is found which is then again
      * deleted since it is to close to the home point. This would not
-     * have any impact on the exploration, but in simulation mode 
-     * (simulation = true) the frontier_ID is steadily up counted. 
-     * This is not necessary! 
+     * have any impact on the exploration, but in simulation mode
+     * (simulation = true) the frontier_ID is steadily up counted.
+     * This is not necessary!
      */
     std::vector<int> goals_to_clear;
-    
+
     for (int i = 1; i < unreachable_frontiers.size(); i++)
     {
         for (int j = 0; j < frontiers.size(); j++)
-	{
+    {
             double diff_x = unreachable_frontiers.at(i).x_coordinate - frontiers.at(j).x_coordinate;
             double diff_y = unreachable_frontiers.at(i).y_coordinate - frontiers.at(j).y_coordinate;
 
@@ -2732,11 +2787,11 @@ void ExplorationPlanner::clearUnreachableFrontiers()
             }
         }
     }
-    
+
 //    for(int i= 0; i< goals_to_clear.size(); i++)
 //    {
-//        removeStoredFrontier(goals_to_clear.at(i)); 
-//    }    
+//        removeStoredFrontier(goals_to_clear.at(i));
+//    }
 }
 
 void ExplorationPlanner::clearSeenFrontiers(costmap_2d::Costmap2DROS *global_costmap)
@@ -2744,11 +2799,11 @@ void ExplorationPlanner::clearSeenFrontiers(costmap_2d::Costmap2DROS *global_cos
 //    ROS_INFO("Clear Seen");
     unsigned int mx, my, point;
     std::vector<int> neighbours, goals_to_clear;
-       
+
 //    this->costmap_global_ros_ = global_costmap;
 //    costmap_global_ros_->getCostmapCopy(costmap_global_);
 //    costmap_global_ros_->getCostmap();
-    
+
 //    ROS_INFO("Map origin  x: %f    y: %f", global_costmap->getCostmap()->getOriginX(), global_costmap->getCostmap()->getOriginY());
 //    ROS_INFO("Map size    x: %d    y: %d", global_costmap->getCostmap()->getSizeInCellsX(), global_costmap->getCostmap()->getSizeInCellsY());
     if(frontiers.size() > 1)
@@ -2756,13 +2811,13 @@ void ExplorationPlanner::clearSeenFrontiers(costmap_2d::Costmap2DROS *global_cos
         for(int i = 0; i < frontiers.size(); i++)
         {
             unsigned int new_mx, new_my;
-            bool unknown_found = false; 
+            bool unknown_found = false;
             bool obstacle_found = false;
             bool freespace_found = false;
 
-            mx = 0; 
+            mx = 0;
             my = 0;
-            
+
            // ROS_INFO("frontier x: %f   y: %f", frontiers.at(i).x_coordinate,frontiers.at(i).y_coordinate);
             if(!global_costmap->getCostmap()->worldToMap(frontiers.at(i).x_coordinate,frontiers.at(i).y_coordinate,mx,my))
             {
@@ -2772,19 +2827,19 @@ void ExplorationPlanner::clearSeenFrontiers(costmap_2d::Costmap2DROS *global_cos
 //            ROS_INFO("Map coordinates mx: %d  my: %d",mx,my);
 
             neighbours = getMapNeighbours(mx, my, 6);
-            
+
 //            ROS_INFO("Neighbours: %lu", neighbours.size());
             for (int j = 0; j < neighbours.size()/2; j++)
             {
 
-               
+
 //                ROS_INFO("Get Neighbour %d and %d",j*2, j*2+1);
                 new_mx = neighbours.at(j*2);
                 new_my = neighbours.at(j*2+1);
 //                ROS_INFO("got access");
-                
-                    
-//                ROS_INFO("Calculating at position x: %d    y: %d", new_mx, new_my);     
+
+
+//                ROS_INFO("Calculating at position x: %d    y: %d", new_mx, new_my);
                 unsigned char cost = global_costmap->getCostmap()->getCost(new_mx, new_my);
 //                ROS_INFO("x position: %d       y position: %d", new_mx, new_my);
 //                ROS_INFO("Got Cost");
@@ -2801,7 +2856,7 @@ void ExplorationPlanner::clearSeenFrontiers(costmap_2d::Costmap2DROS *global_cos
                     obstacle_found = true;
                 }
 //                ROS_INFO("Done");
-            } 
+            }
 
             if(unknown_found == false || obstacle_found == true || freespace_found == false)
             {
@@ -2823,15 +2878,15 @@ void ExplorationPlanner::clearSeenFrontiers(costmap_2d::Costmap2DROS *global_cos
                     }
                 }
                 seen_frontier_list.push_back(frontiers.at(i));
-              
+
             }
         }
-        
+
 //        ROS_INFO("Clearing %lu frontiers", goals_to_clear.size());
 //        for(int i= 0; i< goals_to_clear.size(); i++)
 //        {
 //    //        ROS_DEBUG("Frontier with ID: %d already seen and therefore deleted", goals_to_clear.at(i));
-//            removeStoredFrontier(goals_to_clear.at(i)); 
+//            removeStoredFrontier(goals_to_clear.at(i));
 //        }
     }
 }
@@ -2841,17 +2896,17 @@ bool ExplorationPlanner::smartGoalBackoff(double x, double y, costmap_2d::Costma
     unsigned int mx, my, new_mx, new_my, inner_mx, inner_my;
     double wx, wy;
     std::vector<int> neighbours, inner_neighbours;
-   
+
 //    this->costmap_global_ros_ = global_costmap;
 //    costmap_global_ros_->getCostmapCopy(costmap_global_);
 //    costmap_global_ = costmap_global_ros_;
-    
+
     if(!global_costmap->getCostmap()->worldToMap(x,y,mx,my))
     {
         ROS_ERROR("Cannot convert coordinates successfully.");
     }
 //    ROS_DEBUG("Map coordinates mx: %d  my: %d",mx,my);
-  
+
     neighbours = getMapNeighbours(mx, my, 40);
 //    ROS_DEBUG("Got neighbours");
     for (int j = 0; j< neighbours.size()/2; j++)
@@ -2861,42 +2916,42 @@ bool ExplorationPlanner::smartGoalBackoff(double x, double y, costmap_2d::Costma
         new_my = neighbours.at(j*2+1);
 
         unsigned char cost = global_costmap->getCostmap()->getCost(new_mx, new_my);
-        
+
         if( cost == costmap_2d::FREE_SPACE)
         {
             bool back_off_goal_found = true;
-            
+
             inner_neighbours = getMapNeighbours(new_mx, new_my, INNER_DISTANCE);
             for (int i = 0; i< inner_neighbours.size()/2; i++)
             {
 //                ROS_DEBUG("Get inner neighbours %d and %d",i*2,i*2+1);
                 inner_mx = inner_neighbours.at(i*2);
                 inner_my = inner_neighbours.at(i*2+1);
-                
+
                 unsigned char inner_cost = global_costmap->getCostmap()->getCost(inner_mx, inner_my);
                 if( inner_cost != costmap_2d::FREE_SPACE)
                 {
                     back_off_goal_found = false;
                     break;
-                } 
+                }
             }
-     
+
             if(back_off_goal_found == true)
             {
                 global_costmap->getCostmap()->mapToWorld(new_mx, new_my, wx, wy);
                 new_goal->push_back(wx);
                 new_goal->push_back(wy);
                 return true;
-            }      
+            }
         }
-    }  
+    }
     return false;
 }
 
 std::vector<int> ExplorationPlanner::getMapNeighbours(unsigned int point_x, unsigned int point_y, int distance)
 {
     std::vector<int> neighbours;
-    
+
     for(int i = 0; i< distance; i++)
     {
         neighbours.push_back(point_x+i+1);
@@ -2923,139 +2978,139 @@ void ExplorationPlanner::findFrontiers() {
 
         ROS_INFO("Find Frontiers");
         allFrontiers.clear();
-	int select_frontier = 1;
-	std::vector<double> final_goal,start_points;
-	// list of all frontiers in the occupancy grid
+    int select_frontier = 1;
+    std::vector<double> final_goal,start_points;
+    // list of all frontiers in the occupancy grid
 
 //	// get latest costmap
 //	clearFrontiers();
 
-	/*
-	 * check for all cells in the occupancy grid whether
-	 * or not they are frontier cells. If a possible frontier is found, true is
-	 * returned
-	 */
-	int new_frontier_point = 0;
-	for (unsigned int i = 0; i < num_map_cells_; i++) {
+    /*
+     * check for all cells in the occupancy grid whether
+     * or not they are frontier cells. If a possible frontier is found, true is
+     * returned
+     */
+    int new_frontier_point = 0;
+    for (unsigned int i = 0; i < num_map_cells_; i++) {
 
-		int new_frontier_point = isFrontier(i);
-		if (new_frontier_point != 0) {
-			/*
-			 * If isFrontier() returns true, the point which is checked to be a frontier
-			 * is indeed a frontier.
-			 *
-			 * Push back adds data x to a vector.
-			 * If a frontier was found, the position of the frontier is stored
-			 * in the allFrontiers vector.
-			 */
-			allFrontiers.push_back(new_frontier_point);
-		}
-	}
+        int new_frontier_point = isFrontier(i);
+        if (new_frontier_point != 0) {
+            /*
+             * If isFrontier() returns true, the point which is checked to be a frontier
+             * is indeed a frontier.
+             *
+             * Push back adds data x to a vector.
+             * If a frontier was found, the position of the frontier is stored
+             * in the allFrontiers vector.
+             */
+            allFrontiers.push_back(new_frontier_point);
+        }
+    }
         ROS_INFO("Found %zu frontier cells which are transformed into frontiers points. Starting transformation...", allFrontiers.size());
 
-	/*
-	 * Iterate over all frontiers. The frontiers stored in allFrontiers are
-	 * already REAL frontiers and can be approached by the robot to get new
-	 * informations of the environment.
-	 * To limit the amount of frontiers and only pick those which are valuable to
-	 * drive there, check neighboring frontiers and only remember them if they are
-	 * further then a distance of 40cm away from each other, discard otherwise.
-	 * The rest of the frontiers are stored in a goal buffer which contain all
-	 * frontiers within the map. Additionally check whether or not a newly found
-	 * frontier has already been added to the list. If it is already in the list, do
-	 * not make a new entry with the coordinates of the frontier!
-	 */
-	for (unsigned int i = 0; i < allFrontiers.size(); ++i) {
+    /*
+     * Iterate over all frontiers. The frontiers stored in allFrontiers are
+     * already REAL frontiers and can be approached by the robot to get new
+     * informations of the environment.
+     * To limit the amount of frontiers and only pick those which are valuable to
+     * drive there, check neighboring frontiers and only remember them if they are
+     * further then a distance of 40cm away from each other, discard otherwise.
+     * The rest of the frontiers are stored in a goal buffer which contain all
+     * frontiers within the map. Additionally check whether or not a newly found
+     * frontier has already been added to the list. If it is already in the list, do
+     * not make a new entry with the coordinates of the frontier!
+     */
+    for (unsigned int i = 0; i < allFrontiers.size(); ++i) {
 
-		geometry_msgs::PoseStamped finalFrontier;
-		double wx, wy, wx2, wy2, wx3, wy3;
-		unsigned int mx, my, mx2, my2, mx3, my3;
-		bool result;
+        geometry_msgs::PoseStamped finalFrontier;
+        double wx, wy, wx2, wy2, wx3, wy3;
+        unsigned int mx, my, mx2, my2, mx3, my3;
+        bool result;
 
-                
-		costmap_ros_->getCostmap()->indexToCells(allFrontiers.at(i), mx, my);
-		costmap_ros_->getCostmap()->mapToWorld(mx, my, wx, wy);
-              
+
+        costmap_ros_->getCostmap()->indexToCells(allFrontiers.at(i), mx, my);
+        costmap_ros_->getCostmap()->mapToWorld(mx, my, wx, wy);
+
 //                ROS_INFO("index: %d   map_x: %d   map_y: %d   world_x: %f   world_y: %f", allFrontiers.at(i), mx, my, wx, wy);
-                
-		if(select_frontier == 1)
-		{
-			result = true;
-			for (unsigned int j = 0; j < frontiers.size(); j++)
-			{
-                                if (fabs(wx - frontiers.at(j).x_coordinate) <= MAX_GOAL_RANGE && fabs(wy - frontiers.at(j).y_coordinate) <= MAX_GOAL_RANGE) 
-                                {  
-					result = false;
-					break;
-				}
-			}
-			if (result == true)
-			{
-				storeFrontier(wx,wy,robot_name,robot_str,-1);
-			}
-		}
-		else if(select_frontier == 2)
-		{
-			std::vector<int> neighbour_index;
 
-			for (unsigned int j = 0; j < allFrontiers.size(); ++j)
-			{
-				costmap_ros_->getCostmap()->indexToCells(allFrontiers[j], mx2, my2);
-				costmap_ros_->getCostmap()->mapToWorld(mx2, my2, wx2, wy2);
+        if(select_frontier == 1)
+        {
+            result = true;
+            for (unsigned int j = 0; j < frontiers.size(); j++)
+            {
+                                if (fabs(wx - frontiers.at(j).x_coordinate) <= MAX_GOAL_RANGE && fabs(wy - frontiers.at(j).y_coordinate) <= MAX_GOAL_RANGE)
+                                {
+                    result = false;
+                    break;
+                }
+            }
+            if (result == true)
+            {
+                storeFrontier(wx,wy,robot_name,robot_str,-1);
+            }
+        }
+        else if(select_frontier == 2)
+        {
+            std::vector<int> neighbour_index;
 
-				if (fabs(wx - wx2) <= MINIMAL_FRONTIER_RANGE && fabs(wy - wy2) <= MINIMAL_FRONTIER_RANGE && fabs(wx - wx2) != 0 && fabs(wy - wy2) != 0)
-				{
-					neighbour_index.push_back(allFrontiers[j]);
-				}
-			}
+            for (unsigned int j = 0; j < allFrontiers.size(); ++j)
+            {
+                costmap_ros_->getCostmap()->indexToCells(allFrontiers[j], mx2, my2);
+                costmap_ros_->getCostmap()->mapToWorld(mx2, my2, wx2, wy2);
+
+                if (fabs(wx - wx2) <= MINIMAL_FRONTIER_RANGE && fabs(wy - wy2) <= MINIMAL_FRONTIER_RANGE && fabs(wx - wx2) != 0 && fabs(wy - wy2) != 0)
+                {
+                    neighbour_index.push_back(allFrontiers[j]);
+                }
+            }
 
 
-			for (unsigned int n = 0; n < neighbour_index.size(); ++n)
-			{
-				costmap_ros_->getCostmap()->indexToCells(neighbour_index[n], mx2, my2);
-				costmap_ros_->getCostmap()->mapToWorld(mx2, my2, wx2, wy2);
+            for (unsigned int n = 0; n < neighbour_index.size(); ++n)
+            {
+                costmap_ros_->getCostmap()->indexToCells(neighbour_index[n], mx2, my2);
+                costmap_ros_->getCostmap()->mapToWorld(mx2, my2, wx2, wy2);
 
-				while(true)
-				{
-					bool end_point_found = true;
-					for (unsigned int k = 0; k < allFrontiers.size(); ++k)
-					{
-						costmap_ros_->getCostmap()->indexToCells(allFrontiers[k], mx3, my3);
-						costmap_ros_->getCostmap()->mapToWorld(mx3, my3, wx3, wy3);
+                while(true)
+                {
+                    bool end_point_found = true;
+                    for (unsigned int k = 0; k < allFrontiers.size(); ++k)
+                    {
+                        costmap_ros_->getCostmap()->indexToCells(allFrontiers[k], mx3, my3);
+                        costmap_ros_->getCostmap()->mapToWorld(mx3, my3, wx3, wy3);
 
-						if (fabs(wx2 - wx3) <= MINIMAL_FRONTIER_RANGE && fabs(wy2 - wy3) <= MINIMAL_FRONTIER_RANGE && wx2 != wx3 && wy2 != wy3 && wx != wx3 && wy != wy3)
-						{
-							wx  = wx2;
-							wy  = wy2;
-							wx2 = wx3;
-							wy2 = wy3;
-							end_point_found = false;
-						}
-					}
-					if(end_point_found == true)
-					{
-						start_points.push_back(wx2);
-						start_points.push_back(wy2);
+                        if (fabs(wx2 - wx3) <= MINIMAL_FRONTIER_RANGE && fabs(wy2 - wy3) <= MINIMAL_FRONTIER_RANGE && wx2 != wx3 && wy2 != wy3 && wx != wx3 && wy != wy3)
+                        {
+                            wx  = wx2;
+                            wy  = wy2;
+                            wx2 = wx3;
+                            wy2 = wy3;
+                            end_point_found = false;
+                        }
+                    }
+                    if(end_point_found == true)
+                    {
+                        start_points.push_back(wx2);
+                        start_points.push_back(wy2);
 
-						break;
-					}
-				}
-			}
-			goal_buffer_x.push_back(start_points.at(0)+(start_points.at(2)-start_points.at(0))/2);
-			goal_buffer_y.push_back(start_points.at(1)+(start_points.at(3)-start_points.at(1))/2);
-		}
-	}
+                        break;
+                    }
+                }
+            }
+            goal_buffer_x.push_back(start_points.at(0)+(start_points.at(2)-start_points.at(0))/2);
+            goal_buffer_y.push_back(start_points.at(1)+(start_points.at(3)-start_points.at(1))/2);
+        }
+    }
 
-	ROS_INFO("Size of all frontiers in the list: %zu", frontiers.size());
+    ROS_INFO("Size of all frontiers in the list: %zu", frontiers.size());
 }
 
 
 
 bool ExplorationPlanner::auctioning(std::vector<double> *final_goal, std::vector<int> *clusters_available_in_pool, std::vector<std::string> *robot_str_name)
 {
-    
+
     ROS_INFO("Start Auctioning");
-    
+
    /*
     * Check if Auction is running and wait until it is finished
     */
@@ -3094,7 +3149,7 @@ bool ExplorationPlanner::auctioning(std::vector<double> *final_goal, std::vector
         timer_count++;
         ros::Duration(1).sleep();
     }*/
-    
+
     /*
      * If no auction is running ... clear the auction vector and
      * start a new auction.
@@ -3112,24 +3167,24 @@ bool ExplorationPlanner::auctioning(std::vector<double> *final_goal, std::vector
         ROS_INFO("No auction is running, clearing");
         auction.clear();
     }
-    
-    
+
+
 //    adhoc_communication::AuctionStatus auction_status;
     adhoc_communication::ExpAuction reqest_clusters, auction_msg;
-//    auction_status.start_auction = true; 
+//    auction_status.start_auction = true;
 //    auction_status.auction_finished = false;
-    
-    auction_msg.start_auction = true; 
+
+    auction_msg.start_auction = true;
     auction_msg.auction_finished = false;
     auction_msg.auction_status_message = true;
 
     if(robot_prefix_empty_param == false)
     {
     std::stringstream ss;
-    ss << robot_name; 
+    ss << robot_name;
     std::string prefix = "";
-    robo_name = prefix.append(ss.str());    
-    
+    robo_name = prefix.append(ss.str());
+
     auction_msg.robot_name = robo_name;
     }else
     {
@@ -3139,28 +3194,28 @@ bool ExplorationPlanner::auctioning(std::vector<double> *final_goal, std::vector
     /*
      * visualize all cluster elements
      */
-    
+
 //    for(int i = 0; i < clusters.size(); i++)
 //    {
 //        ROS_INFO("---- Cluster %d ----", clusters.at(i).id);
 //        std::string requested_clusters;
 //        for(int j = 0; j < clusters.at(i).cluster_element.size(); j++)
-//        { 
+//        {
 //            requested_clusters.append(NumberToString((int)clusters.at(i).cluster_element.at(j).id));
 //            requested_clusters.append(", ");
 //        }
 //        ROS_INFO("Cluster ids: %s", requested_clusters.c_str());
 //    }
-    
-     
-    
+
+
+
     for(int i = 0; i < clusters.size(); i++)
     {
         adhoc_communication::ExpCluster cluster_request;
-        
-        
+
+
         for(int j = 0; j < clusters.at(i).cluster_element.size(); j++)
-        { 
+        {
             adhoc_communication::ExpClusterElement cluster_request_element;
             if(robot_prefix_empty_param == true)
             {
@@ -3175,7 +3230,7 @@ bool ExplorationPlanner::auctioning(std::vector<double> *final_goal, std::vector
 //        auction_status.requested_clusters.push_back(cluster_request);
         auction_msg.requested_clusters.push_back(cluster_request);
     }
-    
+
     if(robot_prefix_empty_param == true)
     {
         auction_msg.auction_id = auction_id_number;
@@ -3183,13 +3238,13 @@ bool ExplorationPlanner::auctioning(std::vector<double> *final_goal, std::vector
     {
         auction_msg.auction_id = 10000*robot_name + auction_id_number;
     }
-    
+
     /*
      * Following code is to visualize the message being send to the other robots
      */
 //    for(int i = 0; i< auction_msg.requested_clusters.size(); i++)
 //    {
-//        adhoc_communication::Cluster cluster_req; 
+//        adhoc_communication::Cluster cluster_req;
 //        cluster_req = auction_msg.requested_clusters.at(i);
 //        ROS_INFO("----------------------- REQUEST %d ---------------------------", i);
 //        std::string requested_clusters;
@@ -3201,12 +3256,12 @@ bool ExplorationPlanner::auctioning(std::vector<double> *final_goal, std::vector
 //        ROS_INFO("Auction with auction number: %d", auction_msg.auction_id);
 //        ROS_INFO("Requested ids: %s", requested_clusters.c_str());
 //    }
-    
-     
-    std::string numbers_of_operating_robots; 
-    
+
+
+    std::string numbers_of_operating_robots;
+
     ROS_INFO("Robot %d starting an auction", robot_name);
-    
+
 //    if(first_run == true)
 //    {
 //        pub_auctioning_first.publish(auction_msg);
@@ -3214,9 +3269,9 @@ bool ExplorationPlanner::auctioning(std::vector<double> *final_goal, std::vector
 //    {
         sendToMulticastAuction("mc_", auction_msg, "auction");
 //    }
-    
 
-    
+
+
     /*
      * Wait for results of others
      */
@@ -3233,7 +3288,7 @@ bool ExplorationPlanner::auctioning(std::vector<double> *final_goal, std::vector
 //    nh_robots.param<std::string>("/robots_in_simulation",numbers_of_operating_robots, "1");
 //    number_of_robots = atoi(numbers_of_operating_robots.c_str());
 //    ROS_INFO("++++++++++ number of robots: %d ++++++++++", number_of_robots);
-    
+
     /*
      * Number of responding robots is one less since the robot itself does not
      * respond to its own request
@@ -3263,27 +3318,27 @@ bool ExplorationPlanner::auctioning(std::vector<double> *final_goal, std::vector
     {
         number_of_completed_auctions++;
     }*/
-     
+
 
     /*
      * Select the best cluster for yourself
      */
     ROS_INFO("Selecting the most attractive cluster");
     bool cluster_selected_flag = selectClusterBasedOnAuction(final_goal, clusters_available_in_pool, robot_str_name);
-    
+
     /*
      * Stop the auction
      */
     ROS_INFO("Stop the auction");
-//    auction_status.start_auction = false; 
-//    auction_status.auction_finished = true; 
-    
-    auction_msg.start_auction = false; 
+//    auction_status.start_auction = false;
+//    auction_status.auction_finished = true;
+
+    auction_msg.start_auction = false;
     auction_msg.auction_finished = true;
-    auction_msg.auction_status_message = true;   
+    auction_msg.auction_status_message = true;
     auction_msg.robot_name = robo_name;
     auction_msg.requested_clusters.clear();
-    
+
     if(cluster_selected_flag == true)// && final_goal->size() >= 4)
     {
         /*
@@ -3298,14 +3353,14 @@ bool ExplorationPlanner::auctioning(std::vector<double> *final_goal, std::vector
             auction_element.id = occupied_ids.at(i).id;
             auction_element.detected_by_robot_str = occupied_ids.at(i).robot_str;
             auction_msg.occupied_ids.push_back(auction_element);
-        }        
+        }
     }
 //    else
 //    {
 //        ROS_ERROR("No Goal Selected from selectClusterBasedOnAuction");
-//        cluster_selected_flag = false; 
+//        cluster_selected_flag = false;
 //    }
-    
+
 //    if(first_run == true)
 //    {
 //    pub_auctioning_status.publish(auction_status);
@@ -3314,10 +3369,10 @@ bool ExplorationPlanner::auctioning(std::vector<double> *final_goal, std::vector
 //    {
         sendToMulticastAuction("mc_", auction_msg, "auction");
 //    }
-    
-    first_run = false; 
+
+    first_run = false;
     auction_id_number++;
-    
+
     ROS_INFO("return %d", cluster_selected_flag);
     return (cluster_selected_flag);
 }
@@ -3326,20 +3381,21 @@ bool ExplorationPlanner::auctioning(std::vector<double> *final_goal, std::vector
 
 bool ExplorationPlanner::clusterIdToElementIds(int cluster_id, std::vector<transform_point_t>* occupied_ids)
 {
-    for(int i = 0; i < clusters.size(); i++)
+    for (int i = 0; i < clusters.size(); i++)
     {
-        if(clusters.at(i).id == cluster_id)
+        if (clusters.at(i).id == cluster_id)
         {
-            for(int j = 0; j < clusters.at(i).cluster_element.size(); j++)
+            for (int j = 0; j < clusters.at(i).cluster_element.size(); j++)
             {
                 transform_point_t point;
                 point.id = clusters.at(i).cluster_element.at(j).id;
                 point.robot_str = clusters.at(i).cluster_element.at(j).detected_by_robot_str;
-                
-                occupied_ids->push_back(point);                
+
+                occupied_ids->push_back(point);
             }
         }
     }
+    return true;
 }
 
 std::vector< std::vector<int> > array_to_matrix(int* m, int rows, int cols) {
@@ -3359,32 +3415,32 @@ std::vector< std::vector<int> > array_to_matrix(int* m, int rows, int cols) {
 bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, std::vector<int> *cluster_in_use_already_count, std::vector<std::string> *robot_str_name_to_return)
 {
     ROS_INFO("Select the best cluster based on auction bids");
-    
+
     int own_row_to_select_cluster = 0;
-    int own_column_to_select = 0; 
-    
+    int own_column_to_select = 0;
+
     /*
      * Select the method to select clusters from the matrix.
      * 0 ... select nearest cluster from OWN calculations
      * 1 ... gather information of others, estimate trajectory length based on
-     *       distance information and select the optimal cluster using the 
+     *       distance information and select the optimal cluster using the
      *       KuhnMunkres algorithm.
      */
     int method_used = 2;
-    
+
     int count = 0;
     int auction_cluster_element_id = -1;
-    
-    auction_element_t auction_elements; 
+
+    auction_element_t auction_elements;
     auction_pair_t auction_pair;
-    
+
     /*
      * Calculate my own auction BIDs to all my clusters
      * and store them in the auction vector
      */
     ROS_INFO("Cluster Size: %zu", clusters.size());
     for(int i = 0; i < clusters.size(); i++)
-    {        
+    {
         ROS_INFO("Calculate cluster with ID: %d", clusters.at(i).id);
         int my_auction_bid = calculateAuctionBID(clusters.at(i).id, trajectory_strategy);
         if(my_auction_bid == -1)
@@ -3394,19 +3450,19 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
         ROS_INFO("Own bid calculated for cluster '%d' is '%d'", clusters.at(i).id, my_auction_bid);
         auction_pair.cluster_id = clusters.at(i).id;
         auction_pair.bid_value = my_auction_bid;
-        auction_elements.auction_element.push_back(auction_pair);        
+        auction_elements.auction_element.push_back(auction_pair);
     }
     auction_elements.robot_id = robot_name;
     auction.push_back(auction_elements);
-    
-    
+
+
     /*
      * Remove all clusters which have previously been selected by other robots
      */
-    
+
     std::vector<int> clusters_to_erase;
     for(int j = 0; j < clusters.size(); j++)
-    {           
+    {
         for(int i = 0; i < already_used_ids.size(); i++)
         {
             if(already_used_ids.at(i) == clusters.at(j).id)
@@ -3428,22 +3484,22 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
             }
         }
     }
-  
-    
+
+
     ROS_INFO("Matrix");
-    
+
     /*
      * Calculate the matrix size
      */
     int col = 0, row = 0;
-    
-    int robots_operating; 
+
+    int robots_operating;
     nh.param<int>("robots_in_simulation",robots_operating, 1);
     ROS_INFO("robots operating: %d", robots_operating);
-    
+
     row = auction.size();
-    
-    
+
+
     /* FIXME */
 //    if(auction.size() < robots_operating)
 //    {
@@ -3452,10 +3508,10 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
 //    {
 //        row = auction.size();
 //    }
-    
-    
+
+
 //    for(int i= 0; i < auction.size(); i++)
-//    { 
+//    {
 //        if(auction.at(i).auction_element.size() > col)
 //        {
 //            col = auction.at(i).auction_element.size();
@@ -3466,10 +3522,10 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
     /*
     * create a matrix with boost library
     */
-    
+
     int max_size = std::max(col,row);
     boost::numeric::ublas::matrix<double> m(max_size,max_size);
-    
+
     ROS_INFO("Empty the matrix");
     /*
      * initialize the matrix with all -1
@@ -3481,32 +3537,32 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
             m(i,j) = 0;
         }
     }
-    
-    
+
+
     ROS_INFO("Fill matrix");
     /*
-     * Now fill the matrix with real auction values and use 
+     * Now fill the matrix with real auction values and use
      * a method for the traveling salesman problem
-     * 
+     *
      * i ... number of robots
      * j ... number of clusters
-     */   
+     */
 //    ROS_INFO("robots: %d   clusters: %d", row, col);
     for(int i = 0; i < row; i++)
     {
         ROS_INFO("                 ");
         ROS_INFO("****** i: %d   auction size: %zu ******", i, auction.size());
         for(int j = 0; j < col; j++)
-        {     
+        {
             ROS_INFO("j: %d   cluster size: %zu", j, clusters.size());
             bool found_a_bid = false;
-            bool cluster_valid_flag = false; 
-            
+            bool cluster_valid_flag = false;
+
 //            if(i < auction.size())
-//            {    
+//            {
                 for(int n = 0; n < auction.at(i).auction_element.size(); n++)
-                {            
-                    cluster_valid_flag = true; 
+                {
+                    cluster_valid_flag = true;
 //                    if(j < clusters.size())
 //                    {
 //                        ROS_INFO("j: %d    smaller then clusters.size(): %lu", j, clusters.size());
@@ -3515,7 +3571,7 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
         //                    /*
         //                     * Check if duplicates exist, if so change them
         //                     */
-        //                    bool duplicate_exist = false; 
+        //                    bool duplicate_exist = false;
         //                    for(int k = 0; k < row; k++)
         //                    {
         //                        for(int l = 0; l < col; l++)
@@ -3523,11 +3579,11 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
         //                            if(m(l,k) == auction.at(i).auction_element.at(n).bid_value)
         //                            {
         //                                ROS_INFO("Duplicate found");
-        //                                duplicate_exist = true; 
+        //                                duplicate_exist = true;
         //                            }
         //                        }
         //                    }
-        //                    
+        //
         //                    if(duplicate_exist == false)
         //                    {
         //                        ROS_INFO("assign value");
@@ -3537,29 +3593,29 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
         //                    {
         //                        m(j,i) = auction.at(i).auction_element.at(n).bid_value + 5;
         //                    }
-                            found_a_bid = true; 
+                            found_a_bid = true;
                             break;
                         }
 //                    }else if(j >= clusters.size())
 //                    {
-//                        ROS_ERROR("j >= clusters.size()"); 
-//                        cluster_valid_flag = false; 
+//                        ROS_ERROR("j >= clusters.size()");
+//                        cluster_valid_flag = false;
 //                        row = clusters.size();
 //                        break;
 //                    }
                 }
 //            }else if(i >= auction.size())
 //            {
-//                ROS_ERROR("i >= auction.size()"); 
+//                ROS_ERROR("i >= auction.size()");
 //                col = auction.size();
 //                break;
 //            }
-            
+
             ROS_INFO("Cluster elements checked, found BID: %d", found_a_bid);
-            
+
             /*
              * The auction does not contain a BID value for this cluster,
-             * therefore try to estimate it, using the other robots position. 
+             * therefore try to estimate it, using the other robots position.
              */
             if(found_a_bid == false) // && cluster_valid_flag == true)
             {
@@ -3567,7 +3623,7 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
                 int distance = -1;
                 other_robots_position_x = -1;
                 other_robots_position_y = -1;
-                
+
                 ROS_INFO("---- clusters: %zu element size: %zu  robots positions: %zu ----", clusters.size(), clusters.at(j).cluster_element.size(), other_robots_positions.positions.size());
                 for(int d = 0; d < clusters.at(j).cluster_element.size(); d++)
                 {
@@ -3576,9 +3632,9 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
                     /*Check position of the current robot (i)*/
                     for(int u = 0; u < other_robots_positions.positions.size(); u++)
                     {
-                        adhoc_communication::MmPoint position_of_robot; 
-                        position_of_robot = other_robots_positions.positions.at(u); 
-                        
+                        adhoc_communication::MmPoint position_of_robot;
+                        position_of_robot = other_robots_positions.positions.at(u);
+
                         if(robot_prefix_empty_param == true)
                         {
                             ROS_INFO("position of robot: %s   compare with auction robot: %s", position_of_robot.src_robot.c_str(), auction.at(i).detected_by_robot_str.c_str());
@@ -3586,8 +3642,8 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
                             {
                                 other_robots_position_x = position_of_robot.x;
                                 other_robots_position_y = position_of_robot.y;
-                                
-                                break; 
+
+                                break;
                             }
                             else
                             {
@@ -3608,72 +3664,72 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
                             {
 //                                ROS_ERROR("robot id requested: %d      Current robots position id: %d", auction.at(i).robot_id, robots_int_id);
                                 ROS_ERROR("Unable to look up robots position!");
-                            }                        
-                        }              
+                            }
+                        }
                     }
                     position_mutex.unlock();
-                    
+
 //                    ROS_INFO("Got robot position");
                     if(other_robots_position_x != -1 && other_robots_position_y != -1)
                     {
-                        
+
                         if(trajectory_strategy == "trajectory")
                         {
-                            distance = estimate_trajectory_plan(other_robots_position_x, other_robots_position_y, clusters.at(j).cluster_element.at(d).x_coordinate, clusters.at(j).cluster_element.at(d).y_coordinate);                    
+                            distance = estimate_trajectory_plan(other_robots_position_x, other_robots_position_y, clusters.at(j).cluster_element.at(d).x_coordinate, clusters.at(j).cluster_element.at(d).y_coordinate);
                             ROS_INFO("estimated TRAJECTORY distance is: %d", distance);
-                            
+
                         }else if(trajectory_strategy == "euclidean" && j < clusters.size() && d < clusters.at(j).cluster_element.size())
                         {
                             double x = clusters.at(j).cluster_element.at(d).x_coordinate - other_robots_position_x;
-                            double y = clusters.at(j).cluster_element.at(d).y_coordinate - other_robots_position_y;        
-                            distance = x * x + y * y; 
-                            ROS_INFO("estimated EUCLIDEAN distance is: %d", distance);  
-                            
+                            double y = clusters.at(j).cluster_element.at(d).y_coordinate - other_robots_position_y;
+                            distance = x * x + y * y;
+                            ROS_INFO("estimated EUCLIDEAN distance is: %d", distance);
+
                             if(distance != -1)
-                                break; 
-                        }      
+                                break;
+                        }
                     }
                     /*
-                     * Check if the distance calculation is plausible. 
-                     * The euclidean distance to this point need to be smaller then 
+                     * Check if the distance calculation is plausible.
+                     * The euclidean distance to this point need to be smaller then
                      * the simulated trajectory path. If this stattement is not valid
-                     * the trajectory calculation has failed. 
+                     * the trajectory calculation has failed.
                      */
                     if(distance != -1)
                     {
                         double x = clusters.at(j).cluster_element.at(d).x_coordinate - other_robots_position_x;
-                        double y = clusters.at(j).cluster_element.at(d).y_coordinate - other_robots_position_y;        
+                        double y = clusters.at(j).cluster_element.at(d).y_coordinate - other_robots_position_y;
                         double euclidean_distance = x * x + y * y;
-                    
+
 //                        ROS_INFO("Euclidean distance: %f   trajectory_path: %f", sqrt(euclidean_distance), distance * costmap_ros_->getCostmap()->getResolution());
-                        if (distance * costmap_ros_->getCostmap()->getResolution() <= sqrt(euclidean_distance)*0.95) 
+                        if (distance * costmap_ros_->getCostmap()->getResolution() <= sqrt(euclidean_distance)*0.95)
                         {
                             ROS_ERROR("Euclidean distance is smaller then the trajectory path at recalculation");
                             distance = -1;
                         }else
                         {
                             break;
-                        }     
+                        }
                     }
                 }
                 if(distance == -1)
                 {
                     /*
-                     * Cluster is definitely unknown. Therefore assign a high value 
+                     * Cluster is definitely unknown. Therefore assign a high value
                      * to ensure not to select this cluster
                      */
-                    
+
                     ROS_ERROR("Unable to calculate the others BID at all");
                     m(j,i) = 10000;
                 }
                 else
                 {
                     ROS_INFO("Estimated trajectory length: %d", distance);
-                    
+
 //                    /*
 //                     * Check if duplicates exist, if so change them
 //                     */
-//                    bool duplicate_exist = false; 
+//                    bool duplicate_exist = false;
 //                    for(int k = 0; k < row; k++)
 //                    {
 //                        for(int l = 0; l < col; l++)
@@ -3681,11 +3737,11 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
 //                            if(m(l,k) == distance)
 //                            {
 //                                ROS_INFO("Duplicate found");
-//                                duplicate_exist = true; 
+//                                duplicate_exist = true;
 //                            }
 //                        }
 //                    }
-//                    
+//
 //                    if(duplicate_exist == false)
 //                    {
                         m(j,i) = distance;
@@ -3693,20 +3749,20 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
 //                    {
 //                        m(j,i) = distance +5;
 //                    }
-                }               
+                }
             }
             ROS_INFO("Column filled");
         }
         ROS_INFO("No columns left. Check next robot");
-    }  
+    }
 //    std::cout << m << std::endl;
- 
+
     ROS_INFO("Completed");
-    
+
     /*
-     * If the number of clusters is less the number of robots, 
+     * If the number of clusters is less the number of robots,
      * the assigning algorithmn would not come to a solution. Therefore
-     * select the nearest cluster 
+     * select the nearest cluster
      */
     if(col < row)
     {
@@ -3717,84 +3773,84 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
             /*No clusters are available at all*/
             return false;
         }
-        method_used = 0; 
+        method_used = 0;
     }
-    
+
     /*
      * Select the strategy how to select clusters from the matrix
-     * 
+     *
      * 0 ... select nearest cluster
-     * 1 ... 
+     * 1 ...
      */
     if(method_used == 0)
     {
-       
+
         /*
          * Select the nearest cluster (lowest bid value)
          * THE ROBOTS OWN BIDS ARE IN THE LAST ROW
          * initialize the bid value as first column in the first row
          */
 //        int smallest_bid_value = auction.back().auction_element.front().bid_value;
-    
+
 //        ROS_INFO("smallest_bid_value at initialization: %d", smallest_bid_value);
         ROS_INFO("Columns left: %d", col);
-//        for(int j = 0; j < col; j++) 
-//        { 
+//        for(int j = 0; j < col; j++)
+//        {
 //            ROS_INFO("col: %d", j);
 //            if(auction.back().auction_element.at(j).bid_value <= smallest_bid_value && auction.back().auction_element.at(j).bid_value != -1)
 //            {
 //                smallest_bid_value = auction.back().auction_element.at(j).bid_value;
-//                auction_cluster_element_id = auction.back().auction_element.at(j).cluster_id;                
+//                auction_cluster_element_id = auction.back().auction_element.at(j).cluster_id;
 //            }
 //        }
         if(auction.size() > 0)
         {
             if(auction.back().auction_element.size() > 0)
             {
-                auction_cluster_element_id = auction.back().auction_element.front().cluster_id; 
+                auction_cluster_element_id = auction.back().auction_element.front().cluster_id;
             }else
             {
-                 return false;   
+                 return false;
             }
         }
     }
     if(method_used == 1)
     {
        /*
-        * Use the Ungarische method/ KuhnMunkresAlgorithm in order to figure out which 
+        * Use the Ungarische method/ KuhnMunkresAlgorithm in order to figure out which
         * cluster the most promising one is for myself
         */
-        
+
         /* an example cost matrix */
         int mat[col*row];
-        int counter = 0; 
+        int counter = 0;
         for(int j = 0; j < col; j++)
         {
             for(int i = 0; i < row; i++)
-            { 
+            {
                 mat[counter] = m(j,i);
                 counter++;
             }
         }
-         
+
         std::vector< std::vector<int> > m2 = array_to_matrix(mat,col,row);
-        
+
         /*
          * Last row in the matrix contains BIDs of the robot itself
-         * Remember the max row count before filling up with zeros. 
+         * Remember the max row count before filling up with zeros.
          */
         own_row_to_select_cluster = row-1;
         ROS_INFO("Own row: %d", own_row_to_select_cluster);
-        
+
         /* an example cost matrix */
         int r[3*3] =  {14,15,15,30,1,95,22,14,12};
         std::vector< std::vector<int> > m3 = array_to_matrix(r,3,3);
 
        /* initialize the gungarian_problem using the cost matrix*/
        Hungarian hungarian(m2, col, row, HUNGARIAN_MODE_MINIMIZE_COST);
-       
+
 //        Hungarian hungarian(m3, 3, 3, HUNGARIAN_MODE_MINIMIZE_COST);
-        
+
        fprintf(stderr, "cost-matrix:");
        hungarian.print_cost();
 
@@ -3804,13 +3860,13 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
            if(hungarian.solve() == true)
                break;
        }
-       
-       const std::vector< std::vector<int> > assignment = hungarian.assignment();       
-       
+
+       const std::vector< std::vector<int> > assignment = hungarian.assignment();
+
        /* some output */
        fprintf(stderr, "assignment:");
        hungarian.print_assignment();
-       
+
 //       for(int i = 0; i < assignment.size(); i++)
 //       {
 //           ROS_ERROR("---- %d -----", i);
@@ -3819,8 +3875,8 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
 //               ROS_INFO("%d", assignment.at(i).at(j));
 //           }
 //       }
-       
-       
+
+
        for(int i = 0; i < assignment.size(); i++)
        {
            if(assignment.at(i).at(own_row_to_select_cluster) == 1)
@@ -3834,12 +3890,12 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
     }
     if(method_used == 2)
     {
-        
-	Matrix<double> mat = convert_boost_matrix_to_munkres_matrix<double>(m);
+
+    Matrix<double> mat = convert_boost_matrix_to_munkres_matrix<double>(m);
         ROS_INFO("Matrix (%u %u):",mat.rows(),mat.columns());
-           
-	// Display begin matrix state.
-	for ( int new_row = 0 ; new_row < mat.rows(); new_row++ ) {
+
+    // Display begin matrix state.
+    for ( int new_row = 0 ; new_row < mat.rows(); new_row++ ) {
             if(new_row > 9)
             {
                 int rows_left = mat.rows() - new_row + 1;
@@ -3857,23 +3913,23 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
                 std::cout << mat(new_row,new_col) << " ";
             }
             std::cout << std::endl;
-	}
-	std::cout << std::endl;
+    }
+    std::cout << std::endl;
 
-        
-        
+
+
 //        for(int i = 0; i < mat.columns(); i++)
 //        {
 //            for(int j = 0; j < mat.rows(); j++)
 //            {
 //                /*Inner Matrix*/
-////                bool element_found = false; 
+////                bool element_found = false;
 //                for(int n = 0; n < mat.columns(); n++)
 //                {
 //                    for(int m = 0; m < mat.rows(); m++)
 //                    {
 //                        if(abs(mat(i,j) - mat(n,m)) <= 20 && abs(mat(i,j) - mat(n,m)) != 0 && (mat(i,j) != 0 && mat(n,m) != 0))
-//                        {       
+//                        {
 //                            mat(i,j) = 0;
 ////                            element_found = true;
 ////                            break;
@@ -3881,10 +3937,10 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
 //                    }
 ////                    if(element_found = true)
 ////                        break;
-//                } 
+//                }
 //            }
 //        }
-//        
+//
 //        ROS_INFO("Matrix with threshold :");
 //        // Display begin matrix state.
 //	for ( int new_row = 0 ; new_row < mat.rows(); new_row++ ) {
@@ -3895,15 +3951,15 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
 //		std::cout << std::endl;
 //	}
 //	std::cout << std::endl;
-        
-        
-	// Apply Munkres algorithm to matrix.
-	Munkres munk;
-	munk.solve(mat);
-        
+
+
+    // Apply Munkres algorithm to matrix.
+    Munkres munk;
+    munk.solve(mat);
+
         ROS_INFO("Solved :");
-	// Display solved matrix.
-	for ( int new_row = 0 ; new_row < mat.rows(); new_row++ ) {
+    // Display solved matrix.
+    for ( int new_row = 0 ; new_row < mat.rows(); new_row++ ) {
             if(new_row > 9)
             {
                 int rows_left = mat.rows() - new_row + 1;
@@ -3921,52 +3977,52 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
                 std::cout << mat(new_row,new_col) << " ";
             }
             std::cout << std::endl;
-	}
+    }
 
-	std::cout << std::endl;
-        
-       
+    std::cout << std::endl;
+
+
        own_row_to_select_cluster = row-1;
        for(int i = 0; i < mat.columns(); i++)
        {
            if(mat(i,own_row_to_select_cluster) == 1)
            {
                auction_cluster_element_id = clusters.at(i).id;
-               own_column_to_select = i; 
+               own_column_to_select = i;
                ROS_INFO("Selected Cluster at position : %d   %d  with BID: %f",i ,own_row_to_select_cluster, mat(i, own_row_to_select_cluster));
                break;
            }
        }
-        
-        
-        
-        
+
+
+
+
     }
-   
-    
-    
-    
-    
+
+
+
+
+
     /*
      * Try to navigate to the selected cluster. If it failes, take the next efficient
      * cluster and try again
      */
-    
-           
+
+
     if(auction_cluster_element_id != -1)
-    {  
-        
+    {
+
        /*
         * Select the above calculated goal. If this cluster is still in use,
         * set this cluster in the matrix to zero and restart the auction
         */
-        
-        
-        
-        
-        
+
+
+
+
+
         /*
-         * Following should just be executed if the selection using auctioning 
+         * Following should just be executed if the selection using auctioning
          * does fail
          */
         while(ros::ok())
@@ -3989,16 +4045,16 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
                     double determined_goal_id = new_goal.at(4);
                     bool used_cluster = false;
                     for(int m = 0; m < already_used_ids.size(); m++)
-                    {            
+                    {
                         if(determined_goal_id == already_used_ids.at(m))
                         {
                             ROS_INFO("Cluster in use already");
                             cluster_in_use_already_count->push_back(1);
-                            used_cluster = true; 
+                            used_cluster = true;
                             count++;
                             break;
-                        }     
-                    }  
+                        }
+                    }
                     if(used_cluster == false)
                     {
                         ROS_INFO("Cluster was not used by any robot before");
@@ -4007,13 +4063,13 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
                         goal->push_back(new_goal.at(2));
                         goal->push_back(new_goal.at(3));
                         goal->push_back(new_goal.at(4));
-                        
+
                         robot_str_name_to_return->push_back(robot_str_name.at(0));
-                        return true; 
+                        return true;
                     }
 //                }
             }else
-            {      
+            {
                 if(clusters.size() <= count)
                 {
                     ROS_INFO("Not possible to select any goal from the available clusters");
@@ -4024,14 +4080,14 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
                 }
                 count++;
             }
-        }   
+        }
         return false;
     }else
     {
         /*
          * No auction elements are available. Auctioning has failed
          */
-        
+
         ROS_INFO("Auction has failed, no auction elements are existent. Choosing nearest cluster");
         std::vector<double> new_goal;
         std::vector<std::string> robot_str_name;
@@ -4043,21 +4099,21 @@ bool ExplorationPlanner::selectClusterBasedOnAuction(std::vector<double> *goal, 
             goal->push_back(new_goal.at(2));
             goal->push_back(new_goal.at(3));
             goal->push_back(new_goal.at(4));
-            return true; 
+            return true;
         }else
         {
             return false;
         }
     }
-    return false; 
+    return false;
 }
 
 
 bool ExplorationPlanner::negotiate_Frontier(double x, double y, int detected_by, int id, int cluster_id_number)
 {
-    
+
     ROS_INFO("Negotiating Frontier with id: %d  at Cluster: %d", id, cluster_id_number);
-    
+
     int cluster_vector_position = 0;
     for (int i = 0; i < clusters.size(); i++)
     {
@@ -4066,21 +4122,21 @@ bool ExplorationPlanner::negotiate_Frontier(double x, double y, int detected_by,
             cluster_vector_position = i;
             break;
         }
-    }          
-    
+    }
+
     ROS_DEBUG("cluster vector position: %d", cluster_vector_position);
-    
+
     bool entry_found = false;
     bool id_in_actual_cluster = false;
-    
+
     for(int i = 0; i< negotiation_list.size(); i++)
     {
         for(int k = 0; k < clusters.at(cluster_vector_position).cluster_element.size(); k++)
         {
             id_in_actual_cluster = false;
             if(negotiation_list.at(i).id == clusters.at(cluster_vector_position).cluster_element.at(k).id)
-            {     
-                ROS_INFO("         Same ID detected");   
+            {
+                ROS_INFO("         Same ID detected");
                 for(int j = 0; j < clusters.at(cluster_vector_position).cluster_element.size(); j++)
                 {
                     for(int m = 0; m < my_negotiation_list.size(); m++)
@@ -4107,7 +4163,7 @@ bool ExplorationPlanner::negotiate_Frontier(double x, double y, int detected_by,
                                 used_cluster_ids++;
                             }
                         }
-                    } 
+                    }
 //                    ROS_INFO("%f goals of %f in the cluster  -> %f",used_cluster_ids, (double)clusters.at(cluster_vector_position).cluster_element.size(), double(used_cluster_ids / (double)clusters.at(cluster_vector_position).cluster_element.size()));
                     if(double(used_cluster_ids / (double)clusters.at(cluster_vector_position).cluster_element.size()) >= 0.1)
                     {
@@ -4128,9 +4184,9 @@ bool ExplorationPlanner::negotiate_Frontier(double x, double y, int detected_by,
         new_frontier.id = id;
 
         publish_negotiation_list(new_frontier, cluster_id_number);
-        
+
         return true;
-    }     
+    }
     return false;
 }
 
@@ -4150,7 +4206,7 @@ bool ExplorationPlanner::determine_goal(int strategy, std::vector<double> *final
                     {
                             ROS_INFO("------------------------------------------------------------------");
                             ROS_INFO("Determined frontier with ID: %d   at x: %f     y: %f   detected by Robot %d", frontiers.at(i).id, frontiers.at(i).x_coordinate, frontiers.at(i).y_coordinate, frontiers.at(i).detected_by_robot);
-                            
+
                             /*
                              * Solve the Problem of planning a path to a frontier which is located
                              * directly "in" the obstacle. Therefore back-off 5% of the targets
@@ -4162,18 +4218,18 @@ bool ExplorationPlanner::determine_goal(int strategy, std::vector<double> *final
                             final_goal->push_back(frontiers.at(i).y_coordinate);
                             final_goal->push_back(frontiers.at(i).detected_by_robot);
                             final_goal->push_back(frontiers.at(i).id);
-                            
+
                             robot_str_name->push_back(frontiers.at(i).detected_by_robot_str);
                             return true;
                     }
             }
             return false;
         }
-    
+
         else if(strategy == 2)
         {
             for (int i = 0 + count; i < frontiers.size(); i++)
-            {                    
+            {
                 if (check_efficiency_of_goal(frontiers.at(i).x_coordinate, frontiers.at(i).y_coordinate) == true)
                 {
                         ROS_INFO("------------------------------------------------------------------");
@@ -4183,21 +4239,21 @@ bool ExplorationPlanner::determine_goal(int strategy, std::vector<double> *final
                         final_goal->push_back(frontiers.at(i).y_coordinate);
                         final_goal->push_back(frontiers.at(i).detected_by_robot);
                         final_goal->push_back(frontiers.at(i).id);
-                        
+
                         robot_str_name->push_back(frontiers.at(i).detected_by_robot_str);
                         return true;
                 }
             }
-        }    
+        }
         else if(strategy == 3)
         {
             while(true)
             {
                 if(frontiers.size() > 0)
                 {
-                    
+
                     int i = int(frontiers.size()*rand()/(RAND_MAX));
-                   
+
                     ROS_INFO("Random frontier ID: %d", frontiers.at(i).id);
 
                     if (check_efficiency_of_goal(frontiers.at(i).x_coordinate, frontiers.at(i).y_coordinate) == true)
@@ -4209,37 +4265,37 @@ bool ExplorationPlanner::determine_goal(int strategy, std::vector<double> *final
                             final_goal->push_back(frontiers.at(i).y_coordinate);
                             final_goal->push_back(frontiers.at(i).detected_by_robot);
                             final_goal->push_back(frontiers.at(i).id);
-                            
+
                             robot_str_name->push_back(frontiers.at(i).detected_by_robot_str);
                             return true;
                     }
                 }
                 break;
-            }  
-	}
+            }
+    }
         else if(strategy == 4)
         {
                 int cluster_vector_position = 0;
- 
+
                 if(actual_cluster_id != -1)
                 {
                     if(clusters.size() > 0)
-                    {                   
+                    {
                         for (int i = 0; i < clusters.size(); i++)
                         {
                             if(clusters.at(i).id == actual_cluster_id)
                             {
                                 if(clusters.at(i).cluster_element.size() > 0)
                                 {
-                                    cluster_vector_position = i; 
+                                    cluster_vector_position = i;
                                 }
                                 break;
                             }
                         }
                     }
                 }
-               
-                ROS_INFO("Calculated vector position of cluster %d", actual_cluster_id);   
+
+                ROS_INFO("Calculated vector position of cluster %d", actual_cluster_id);
                 /*
                  * Iterate over all clusters .... if cluster_vector_position is set
                  * also the clusters with a lower have to be checked if the frontier
@@ -4255,12 +4311,12 @@ bool ExplorationPlanner::determine_goal(int strategy, std::vector<double> *final
                     i = i+ cluster_vector_position;
                     i = i % (clusters.size());
                     for (int j = 0; j < clusters.at(i).cluster_element.size(); j++)
-                    {                    
+                    {
                         if (check_efficiency_of_goal(clusters.at(i).cluster_element.at(j).x_coordinate, clusters.at(i).cluster_element.at(j).y_coordinate) == true)
                         {
                                 ROS_INFO("------------------------------------------------------------------");
                                 ROS_INFO("Robot %d determined Goal: %d  at Clusters: %d",robot_name, (int)clusters.at(i).cluster_element.at(j).id, (int)clusters.at(i).id);
-                                
+
                                 final_goal->push_back(clusters.at(i).cluster_element.at(j).x_coordinate);
                                 final_goal->push_back(clusters.at(i).cluster_element.at(j).y_coordinate);
                                 final_goal->push_back(clusters.at(i).cluster_element.at(j).detected_by_robot);
@@ -4271,12 +4327,12 @@ bool ExplorationPlanner::determine_goal(int strategy, std::vector<double> *final
                                 robot_str_name->push_back(clusters.at(i).cluster_element.at(j).detected_by_robot_str);
                                 return true;
                         }
-                        
+
                     }
-                  
+
                     nothing_found_in_actual_cluster ++;
                     visited_clusters ++;
-                    
+
                     if(nothing_found_in_actual_cluster == 1)
                     {
                         //start again at the beginning(closest cluster))
@@ -4288,36 +4344,36 @@ bool ExplorationPlanner::determine_goal(int strategy, std::vector<double> *final
                     {
                         break;
                     }
-               }               
+               }
             }
             else if(strategy == 5)
             {
                 int cluster_vector_position = 0;
-                bool cluster_could_be_found = false; 
-                
+                bool cluster_could_be_found = false;
+
                 if(actual_cluster_id != -1)
                 {
                     if(clusters.size() > 0)
-                    {                   
+                    {
                         for (int i = 0; i < clusters.size(); i++)
                         {
                             if(clusters.at(i).id == actual_cluster_id)
                             {
                                 if(clusters.at(i).cluster_element.size() > 0)
                                 {
-                                    cluster_vector_position = i; 
+                                    cluster_vector_position = i;
                                     cluster_could_be_found = true;
                                     break;
                                 }
                             }
-                        }                      
+                        }
                     }
                     if(cluster_could_be_found == false)
                     {
                         /*
                          * The cluster we operated in is now empty
                          */
-                        return false; 
+                        return false;
                     }
                 }
                 else if(actual_cluster_id == -1)
@@ -4326,7 +4382,7 @@ bool ExplorationPlanner::determine_goal(int strategy, std::vector<double> *final
                     final_goal->push_back(-1.0);
                     return false;
                 }
-                ROS_INFO("Calculated vector position: %d of cluster %d", cluster_vector_position, actual_cluster_id);   
+                ROS_INFO("Calculated vector position: %d of cluster %d", cluster_vector_position, actual_cluster_id);
                 /*
                  * Iterate over all clusters .... if cluster_vector_position is set
                  * also the clusters with a lower have to be checked if the frontier
@@ -4336,13 +4392,13 @@ bool ExplorationPlanner::determine_goal(int strategy, std::vector<double> *final
                  */
                 int nothing_found_in_actual_cluster = 0;
                 int visited_clusters = 0;
-              
+
 //                if(clusters.size() > 0)
 //                {
-               
+
                     int position = (cluster_vector_position +count) % (clusters.size());
                     for (int j = 0; j < clusters.at(position).cluster_element.size(); j++)
-                    {     
+                    {
                         if(count >= clusters.size())
                         {
                             break;
@@ -4368,40 +4424,40 @@ bool ExplorationPlanner::determine_goal(int strategy, std::vector<double> *final
                         }
 
                     }
-                
+
 //                }
 //                ROS_INFO("No clusters are available anymore");
-                
-                return false;                                
+
+                return false;
             }
             else if(strategy == 6)
             {
                 int cluster_vector_position = 0;
-                bool cluster_could_be_found = false; 
-                
+                bool cluster_could_be_found = false;
+
                 if(actual_cluster_id != -1)
                 {
                     if(clusters.size() > 0)
-                    {                   
+                    {
                         for (int i = 0; i < clusters.size(); i++)
                         {
                             if(clusters.at(i).id == actual_cluster_id)
                             {
                                 if(clusters.at(i).cluster_element.size() > 0)
                                 {
-                                    cluster_vector_position = i; 
+                                    cluster_vector_position = i;
                                     cluster_could_be_found = true;
                                     break;
                                 }
                             }
-                        }                      
+                        }
                     }
                     if(cluster_could_be_found == false)
                     {
                         /*
                          * The cluster we operated in is now empty
                          */
-                        return false; 
+                        return false;
                     }
                 }
                 else if(actual_cluster_id == -1)
@@ -4410,7 +4466,7 @@ bool ExplorationPlanner::determine_goal(int strategy, std::vector<double> *final
                     final_goal->push_back(-1.0);
                     return false;
                 }
-                ROS_INFO("Calculated vector position: %d of cluster %d", cluster_vector_position, actual_cluster_id);   
+                ROS_INFO("Calculated vector position: %d of cluster %d", cluster_vector_position, actual_cluster_id);
                 /*
                  * Iterate over all clusters .... if cluster_vector_position is set
                  * also the clusters with a lower have to be checked if the frontier
@@ -4420,11 +4476,11 @@ bool ExplorationPlanner::determine_goal(int strategy, std::vector<double> *final
                  */
                 int nothing_found_in_actual_cluster = 0;
                 int visited_clusters = 0;
-                              
+
 //                    ROS_INFO("position: %lu", (cluster_vector_position +count) % (clusters.size()));
                     int position = (cluster_vector_position +count) % (clusters.size());
                     for (int j = 0; j < clusters.at(position).cluster_element.size(); j++)
-                    {     
+                    {
                         if(count >= clusters.size())
                         {
                             break;
@@ -4450,32 +4506,33 @@ bool ExplorationPlanner::determine_goal(int strategy, std::vector<double> *final
 //                            else
 //                            {
 //                                final_goal->push_back(-1);
-//                                return true; 
+//                                return true;
 //                            }
                         }
 
                     }
-                return false;                                
+                return false;
             }
      return false;
 }
 
 bool sortCluster(const ExplorationPlanner::cluster_t &lhs, const ExplorationPlanner::cluster_t &rhs)
-{   
-    if(lhs.cluster_element.size() > 1 && rhs.cluster_element.size() > 1)
+{
+    if (lhs.cluster_element.size() > 1 && rhs.cluster_element.size() > 1)
     {
-        return lhs.cluster_element.front().dist_to_robot < rhs.cluster_element.front().dist_to_robot; 
+        return lhs.cluster_element.front().dist_to_robot < rhs.cluster_element.front().dist_to_robot;
     }
+    return false;
 }
 
 void ExplorationPlanner::sort(int strategy)
 {
 //    ROS_INFO("Sorting");
         /*
-         * Following Sort algorithm normalizes all distances to the 
-         * robots actual position. As result, the list is sorted 
+         * Following Sort algorithm normalizes all distances to the
+         * robots actual position. As result, the list is sorted
          * from smallest to biggest deviation between goal point and
-         * robot! 
+         * robot!
          */
         if(strategy == 1)
         {
@@ -4484,8 +4541,8 @@ void ExplorationPlanner::sort(int strategy)
             {
                     ROS_ERROR("Failed to get RobotPose");
             }
-            
-            if (frontiers.size() > 0) 
+
+            if (frontiers.size() > 0)
             {
                     for (int i = frontiers.size(); i >= 0; i--) {
                             for (int j = 0; j < frontiers.size() - 1; j++) {
@@ -4497,13 +4554,13 @@ void ExplorationPlanner::sort(int strategy)
                                     double euclidean_distance_next = x_next * x_next + y_next * y_next;
 
                                     if (sqrt(euclidean_distance) > sqrt(euclidean_distance_next)) {
-                                            frontier_t temp = frontiers.at(j+1);                                            
-                                            frontiers.at(j + 1) = frontiers.at(j);                                          
-                                            frontiers.at(j) = temp;                  
+                                            frontier_t temp = frontiers.at(j+1);
+                                            frontiers.at(j + 1) = frontiers.at(j);
+                                            frontiers.at(j) = temp;
                                     }
                             }
                     }
-            } else 
+            } else
             {
                     ROS_INFO("Sorting not possible, no frontiers available!!!");
             }
@@ -4515,10 +4572,10 @@ void ExplorationPlanner::sort(int strategy)
             {
                     ROS_ERROR("Failed to get RobotPose");
             }
-            
-            if (frontiers.size() > 0) 
+
+            if (frontiers.size() > 0)
             {
-                    for (int i = frontiers.size(); i >= 0; i--) 
+                    for (int i = frontiers.size(); i >= 0; i--)
                     {
                             for (int j = 0; j < frontiers.size() - 1; j++) {
                                     double x = frontiers.at(j).x_coordinate - robotPose.getOrigin().getX();
@@ -4529,13 +4586,13 @@ void ExplorationPlanner::sort(int strategy)
                                     double euclidean_distance_next = x_next * x_next + y_next * y_next;
 
                                     if (sqrt(euclidean_distance) > sqrt(euclidean_distance_next)) {
-                                            frontier_t temp = frontiers.at(j+1);                                            
-                                            frontiers.at(j + 1) = frontiers.at(j);                                          
-                                            frontiers.at(j) = temp;                  
+                                            frontier_t temp = frontiers.at(j+1);
+                                            frontiers.at(j + 1) = frontiers.at(j);
+                                            frontiers.at(j) = temp;
                                     }
                             }
                     }
-            }else 
+            }else
             {
                     ROS_INFO("Sorting not possible, no frontiers available!!!");
             }
@@ -4547,12 +4604,12 @@ void ExplorationPlanner::sort(int strategy)
             {
                     ROS_ERROR("Failed to get RobotPose");
             }
-            
-            if (frontiers.size() > 0) 
-            {  
+
+            if (frontiers.size() > 0)
+            {
                 check_trajectory_plan();
 
-                for (int i = frontiers.size(); i >= frontiers.size()-10; i--) 
+                for (int i = frontiers.size(); i >= frontiers.size()-10; i--)
                 {
 
 
@@ -4562,7 +4619,7 @@ void ExplorationPlanner::sort(int strategy)
                     }
                     else
                     {
-                        for (int j = 0; j < 10-1; j++) 
+                        for (int j = 0; j < 10-1; j++)
                         {
                             if(j >= frontiers.size())
                             {
@@ -4570,19 +4627,19 @@ void ExplorationPlanner::sort(int strategy)
                             }else
                             {
 
-                                int dist = frontiers.at(j).distance_to_robot;                                   
+                                int dist = frontiers.at(j).distance_to_robot;
                                 int dist_next = frontiers.at(j+1).distance_to_robot;
 
-                                if (dist > dist_next) {                                          
-                                        frontier_t temp = frontiers.at(j+1);                                            
-                                        frontiers.at(j + 1) = frontiers.at(j);                                          
-                                        frontiers.at(j) = temp;                                          
+                                if (dist > dist_next) {
+                                        frontier_t temp = frontiers.at(j+1);
+                                        frontiers.at(j + 1) = frontiers.at(j);
+                                        frontiers.at(j) = temp;
                                 }
                             }
                         }
                     }
                 }
-            } else 
+            } else
             {
                     ROS_INFO("Sorting not possible, no frontiers available!!!");
             }
@@ -4601,13 +4658,13 @@ void ExplorationPlanner::sort(int strategy)
             {
                 for(int cluster_number = 0; cluster_number < clusters.size(); cluster_number++)
                 {
-                    if (clusters.at(cluster_number).cluster_element.size() > 0) 
+                    if (clusters.at(cluster_number).cluster_element.size() > 0)
                     {
                         ROS_DEBUG("Cluster %d  size: %zu",cluster_number, clusters.at(cluster_number).cluster_element.size());
-                            for (int i = clusters.at(cluster_number).cluster_element.size(); i > 0; i--) 
+                            for (int i = clusters.at(cluster_number).cluster_element.size(); i > 0; i--)
                             {
                                 ROS_DEBUG("Cluster element size: %d", i);
-                                    for (int j = 0; j < clusters.at(cluster_number).cluster_element.size()-1; j++) 
+                                    for (int j = 0; j < clusters.at(cluster_number).cluster_element.size()-1; j++)
                                     {
                                         ROS_DEBUG("Cluster element number: %d", j);
                                         double x = clusters.at(cluster_number).cluster_element.at(j).x_coordinate - pose_x;
@@ -4619,17 +4676,17 @@ void ExplorationPlanner::sort(int strategy)
 
 //                                        int distance = check_trajectory_plan(clusters.at(cluster_number).cluster_element.at(j).x_coordinate, clusters.at(cluster_number).cluster_element.at(j).y_coordinate);
 //                                        int distance_next = check_trajectory_plan(clusters.at(cluster_number).cluster_element.at(j+1).x_coordinate,clusters.at(cluster_number).cluster_element.at(j+1).y_coordinate);
-                                    
-//                                        if(distance > distance_next) 
-                                        if (sqrt(euclidean_distance) > sqrt(euclidean_distance_next)) 
+
+//                                        if(distance > distance_next)
+                                        if (sqrt(euclidean_distance) > sqrt(euclidean_distance_next))
                                         {
-                                                frontier_t temp = clusters.at(cluster_number).cluster_element.at(j+1);                                            
-                                                clusters.at(cluster_number).cluster_element.at(j+1) = clusters.at(cluster_number).cluster_element.at(j);                                          
-                                                clusters.at(cluster_number).cluster_element.at(j) = temp;                  
+                                                frontier_t temp = clusters.at(cluster_number).cluster_element.at(j+1);
+                                                clusters.at(cluster_number).cluster_element.at(j+1) = clusters.at(cluster_number).cluster_element.at(j);
+                                                clusters.at(cluster_number).cluster_element.at(j) = temp;
                                         }
                                     }
                             }
-                    }else 
+                    }else
                     {
 //                         ROS_INFO("Sorting not possible, no elements available!!!");
                     }
@@ -4638,7 +4695,7 @@ void ExplorationPlanner::sort(int strategy)
             {
                 ROS_INFO("Sorting not possible, no clusters available!!!");
             }
-        }        
+        }
         else if(strategy == 5)
         {
             ROS_INFO("sort(5)");
@@ -4649,9 +4706,9 @@ void ExplorationPlanner::sort(int strategy)
             }
             double pose_x = robotPose.getOrigin().getX();
             double pose_y = robotPose.getOrigin().getY();
-            
+
             ROS_DEBUG("Iterating over all cluster elements");
-            
+
             for(int i = 0; i < clusters.size(); i++)
             {
                 for(int j = 0; j < clusters.at(i).cluster_element.size(); j++)
@@ -4659,7 +4716,7 @@ void ExplorationPlanner::sort(int strategy)
                     clusters.at(i).cluster_element.at(j).dist_to_robot = 0;
                 }
             }
-            
+
             for(int i = 0; i < clusters.size(); i++)
             {
                 if(clusters.at(i).cluster_element.size() > 0)
@@ -4671,12 +4728,12 @@ void ExplorationPlanner::sort(int strategy)
                         double y = clusters.at(i).cluster_element.at(j).y_coordinate - pose_y;
                         double euclidean_distance = x * x + y * y;
                         int distance = euclidean_distance;
-                        
+
                         clusters.at(i).cluster_element.at(j).dist_to_robot = sqrt(distance);
-                        
+
                         /* ********** TRAVEL PATH ********** */
 //                        int distance = check_trajectory_plan(clusters.at(i).cluster_element.at(j).x_coordinate, clusters.at(i).cluster_element.at(j).y_coordinate);
-                                                
+
 //                        clusters.at(i).cluster_element.at(j).dist_to_robot = distance;
                     }
                 }else
@@ -4693,43 +4750,43 @@ void ExplorationPlanner::sort(int strategy)
             }
             ROS_INFO("Starting to sort the clusters itself");
             std::sort(clusters.begin(), clusters.end(), sortCluster);
-            
-//            if (clusters.size() > 0) 
+
+//            if (clusters.size() > 0)
 //            {
-//                    for (int i = clusters.size(); i > 0; i--) 
-//                    {                   
-//                            for (int j = 0; j < clusters.size() - 1; j++) 
+//                    for (int i = clusters.size(); i > 0; i--)
+//                    {
+//                            for (int j = 0; j < clusters.size() - 1; j++)
 //                            {
 ////                                ROS_ERROR("Compare cluster: %d id: %d    ||    cluster: %d id: %d", j, clusters.at(j).cluster_element.front().id, j+1, clusters.at(j+1).cluster_element.front().id);
 //                                if(clusters.at(j).cluster_element.size() > 0 && clusters.at(j+1).cluster_element.size() > 0)
 //                                {
-//                                    
+//
 //                                    double x = clusters.at(j).cluster_element.front().x_coordinate - pose_x;
 //                                    double y = clusters.at(j).cluster_element.front().y_coordinate - pose_y;
 //                                    double x_next = clusters.at(j+1).cluster_element.front().x_coordinate - pose_x;
 //                                    double y_next = clusters.at(j+1).cluster_element.front().y_coordinate - pose_y;
-//                                                                       
+//
 //                                    double euclidean_distance = x * x + y * y;
 //                                    double euclidean_distance_next = x_next * x_next + y_next * y_next;
-//                                    
+//
 ////                                  ROS_INFO("Cluster %d dist: %d     Cluster %d dist: %d",j,(int)euclidean_distance, j+1, (int)euclidean_distance_next);
 //                                    clusters.at(j).cluster_element.front().dist_to_robot = euclidean_distance;
 //                                    clusters.at(j+1).cluster_element.front().dist_to_robot = euclidean_distance_next;
-//                                    
+//
 ////                                    int distance = check_trajectory_plan(clusters.at(j).cluster_element.front().x_coordinate, clusters.at(j).cluster_element.front().y_coordinate);
 ////                                    int distance_next = check_trajectory_plan(clusters.at(j+1).cluster_element.front().x_coordinate,clusters.at(j+1).cluster_element.front().y_coordinate);
-//                                    
+//
 ////                                    if(distance > distance_next)
-//                                    if (sqrt(euclidean_distance) > sqrt(euclidean_distance_next)) 
+//                                    if (sqrt(euclidean_distance) > sqrt(euclidean_distance_next))
 //                                    {
-//                                            cluster_t temp = clusters.at(j+1);                                            
-//                                            clusters.at(j+1) = clusters.at(j);                                          
-//                                            clusters.at(j) = temp;                  
+//                                            cluster_t temp = clusters.at(j+1);
+//                                            clusters.at(j+1) = clusters.at(j);
+//                                            clusters.at(j) = temp;
 //                                    }
 //                                }
 //                            }
 //                    }
-//            }else 
+//            }else
 //            {
 //                    ROS_INFO("Sorting not possible, no frontiers available!!!");
 //            }
@@ -4744,15 +4801,15 @@ void ExplorationPlanner::sort(int strategy)
             }
             double pose_x = robotPose.getOrigin().getX();
             double pose_y = robotPose.getOrigin().getY();
-            
+
             ROS_DEBUG("Iterating over all cluster elements");
-            
+
             for(int i = 0; i < clusters.size(); i++)
             {
                 if(clusters.at(i).cluster_element.size() > 0)
                 {
                     for(int j = 0; j < clusters.at(i).cluster_element.size(); j++)
-                    {  
+                    {
                         random_value = int(rand() % 100);
                         clusters.at(i).cluster_element.at(j).dist_to_robot = random_value;
                     }
@@ -4767,11 +4824,11 @@ void ExplorationPlanner::sort(int strategy)
                 }
             }
             ROS_DEBUG("Starting to sort the clusters itself");
-            std::sort(clusters.begin(), clusters.end(), sortCluster);  
-        }  
-        
+            std::sort(clusters.begin(), clusters.end(), sortCluster);
+        }
+
         ROS_INFO("Done sorting");
-    
+
 //	for (int i = frontiers.size() -1 ; i >= 0; i--) {
 //		ROS_ERROR("Frontier with ID: %d   at x: %f     y: %f   detected by Robot %d", frontiers.at(i).id, frontiers.at(i).x_coordinate, frontiers.at(i).y_coordinate, frontiers.at(i).detected_by_robot);
 //	}
@@ -4779,45 +4836,45 @@ void ExplorationPlanner::sort(int strategy)
 
 void ExplorationPlanner::simulate() {
 
-	geometry_msgs::PointStamped goalPoint;
-	
+    geometry_msgs::PointStamped goalPoint;
 
-	tf::Stamped < tf::Pose > robotPose;
-	if (!costmap_ros_->getRobotPose(robotPose))
-	{
-		ROS_ERROR("Failed to get RobotPose");
-	}
-	// Visualize in RVIZ
 
-	for (int i = frontiers.size() - 1; i >= 0; i--) {
+    tf::Stamped < tf::Pose > robotPose;
+    if (!costmap_ros_->getRobotPose(robotPose))
+    {
+        ROS_ERROR("Failed to get RobotPose");
+    }
+    // Visualize in RVIZ
+
+    for (int i = frontiers.size() - 1; i >= 0; i--) {
             goalPoint.header.seq = i + 1;
             goalPoint.header.stamp = ros::Time::now();
             goalPoint.header.frame_id = "map";
             goalPoint.point.x = frontiers.at(i).x_coordinate;
             goalPoint.point.y = frontiers.at(i).y_coordinate;
-                     
+
             pub_Point.publish < geometry_msgs::PointStamped > (goalPoint);
 
             ros::Duration(1.0).sleep();
-	}
+    }
 }
 
 void ExplorationPlanner::clear_Visualized_Cluster_Cells(std::vector<int> ids)
 {
     nav_msgs::GridCells clearing_cell;
     geometry_msgs::Point point;
-    
-    clearing_cell.header.frame_id = move_base_frame;    
+
+    clearing_cell.header.frame_id = move_base_frame;
     clearing_cell.header.stamp = ros::Time::now();
     clearing_cell.cell_height = 0.1;
     clearing_cell.cell_width = 0.1;
     clearing_cell.header.seq = cluster_cells_seq_number++;
-   
+
     point.x = 1000;
     point.y = 1000;
     point.z = 1000;
     clearing_cell.cells.push_back(point);
-    
+
     for(int i = 0; i < 20; i++)
     {
         bool used_id = false;
@@ -4825,93 +4882,93 @@ void ExplorationPlanner::clear_Visualized_Cluster_Cells(std::vector<int> ids)
         {
             if(ids.at(n) == i)
             {
-               used_id = true; 
+               used_id = true;
                break;
             }
         }
         if(used_id == false)
-        {      
+        {
             if(i == 0)
             {
-                pub_cluster_grid_0.publish<nav_msgs::GridCells>(clearing_cell); 
+                pub_cluster_grid_0.publish<nav_msgs::GridCells>(clearing_cell);
             }
             if(i == 1)
             {
-                pub_cluster_grid_1.publish<nav_msgs::GridCells>(clearing_cell); 
+                pub_cluster_grid_1.publish<nav_msgs::GridCells>(clearing_cell);
             }
             if(i == 2)
             {
-                pub_cluster_grid_2.publish<nav_msgs::GridCells>(clearing_cell); 
+                pub_cluster_grid_2.publish<nav_msgs::GridCells>(clearing_cell);
             }
             if(i == 3)
             {
-                pub_cluster_grid_3.publish<nav_msgs::GridCells>(clearing_cell); 
+                pub_cluster_grid_3.publish<nav_msgs::GridCells>(clearing_cell);
             }
             if(i == 4)
             {
-                pub_cluster_grid_4.publish<nav_msgs::GridCells>(clearing_cell); 
+                pub_cluster_grid_4.publish<nav_msgs::GridCells>(clearing_cell);
             }
             if(i == 5)
             {
-                pub_cluster_grid_5.publish<nav_msgs::GridCells>(clearing_cell); 
+                pub_cluster_grid_5.publish<nav_msgs::GridCells>(clearing_cell);
             }
             if(i == 6)
             {
-                pub_cluster_grid_6.publish<nav_msgs::GridCells>(clearing_cell); 
+                pub_cluster_grid_6.publish<nav_msgs::GridCells>(clearing_cell);
             }
             if(i == 7)
             {
-                pub_cluster_grid_7.publish<nav_msgs::GridCells>(clearing_cell); 
+                pub_cluster_grid_7.publish<nav_msgs::GridCells>(clearing_cell);
             }
             if(i == 8)
             {
-                pub_cluster_grid_8.publish<nav_msgs::GridCells>(clearing_cell); 
+                pub_cluster_grid_8.publish<nav_msgs::GridCells>(clearing_cell);
             }
             if(i == 9)
             {
-                pub_cluster_grid_9.publish<nav_msgs::GridCells>(clearing_cell); 
+                pub_cluster_grid_9.publish<nav_msgs::GridCells>(clearing_cell);
             }
 
             if(i == 10)
             {
-                pub_cluster_grid_10.publish<nav_msgs::GridCells>(clearing_cell); 
+                pub_cluster_grid_10.publish<nav_msgs::GridCells>(clearing_cell);
             }
             if(i == 11)
             {
-                pub_cluster_grid_11.publish<nav_msgs::GridCells>(clearing_cell); 
+                pub_cluster_grid_11.publish<nav_msgs::GridCells>(clearing_cell);
             }
             if(i == 12)
             {
-                pub_cluster_grid_12.publish<nav_msgs::GridCells>(clearing_cell); 
+                pub_cluster_grid_12.publish<nav_msgs::GridCells>(clearing_cell);
             }
             if(i == 13)
             {
-                pub_cluster_grid_13.publish<nav_msgs::GridCells>(clearing_cell); 
+                pub_cluster_grid_13.publish<nav_msgs::GridCells>(clearing_cell);
             }
             if(i == 14)
             {
-                pub_cluster_grid_14.publish<nav_msgs::GridCells>(clearing_cell); 
+                pub_cluster_grid_14.publish<nav_msgs::GridCells>(clearing_cell);
             }
             if(i == 15)
             {
-                pub_cluster_grid_15.publish<nav_msgs::GridCells>(clearing_cell); 
+                pub_cluster_grid_15.publish<nav_msgs::GridCells>(clearing_cell);
             }
             if(i == 16)
             {
-                pub_cluster_grid_16.publish<nav_msgs::GridCells>(clearing_cell); 
+                pub_cluster_grid_16.publish<nav_msgs::GridCells>(clearing_cell);
             }
             if(i == 17)
             {
-                pub_cluster_grid_17.publish<nav_msgs::GridCells>(clearing_cell); 
+                pub_cluster_grid_17.publish<nav_msgs::GridCells>(clearing_cell);
             }
             if(i == 18)
             {
-                pub_cluster_grid_18.publish<nav_msgs::GridCells>(clearing_cell); 
+                pub_cluster_grid_18.publish<nav_msgs::GridCells>(clearing_cell);
             }
             if(i == 19)
             {
-                pub_cluster_grid_19.publish<nav_msgs::GridCells>(clearing_cell); 
-            } 
+                pub_cluster_grid_19.publish<nav_msgs::GridCells>(clearing_cell);
+            }
         }
     }
 }
@@ -4919,8 +4976,8 @@ void ExplorationPlanner::clear_Visualized_Cluster_Cells(std::vector<int> ids)
 
 void ExplorationPlanner::visualize_Cluster_Cells()
 {
-    ROS_INFO("Visualize clusters");  
-            
+    ROS_INFO("Visualize clusters");
+
     std::vector<int> used_ids;
     for(int i= 0; i< clusters.size(); i++)
     {
@@ -4935,95 +4992,95 @@ void ExplorationPlanner::visualize_Cluster_Cells()
                 point.z = 0;
 
                 cluster_cells.cells.push_back(point);
-            }     
-            cluster_cells.header.frame_id = move_base_frame;    
+            }
+            cluster_cells.header.frame_id = move_base_frame;
             cluster_cells.header.stamp = ros::Time::now();
             cluster_cells.cell_height = 0.5;
             cluster_cells.cell_width = 0.5;
             cluster_cells.header.seq = cluster_cells_seq_number++;
-           
+
             used_ids.push_back(clusters.at(i).id % 20);
-            
+
             if(clusters.at(i).id % 20 == 0)
             {
-                pub_cluster_grid_0.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_0.publish<nav_msgs::GridCells>(cluster_cells);
             }
             else if(clusters.at(i).id % 20 == 1)
             {
-                pub_cluster_grid_1.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_1.publish<nav_msgs::GridCells>(cluster_cells);
             }
             else if(clusters.at(i).id % 20 == 2)
             {
-                pub_cluster_grid_2.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_2.publish<nav_msgs::GridCells>(cluster_cells);
             }
             else if(clusters.at(i).id % 20 == 3)
             {
-                pub_cluster_grid_3.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_3.publish<nav_msgs::GridCells>(cluster_cells);
             }
             else if(clusters.at(i).id % 20 == 4)
             {
-                pub_cluster_grid_4.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_4.publish<nav_msgs::GridCells>(cluster_cells);
             }
             else if(clusters.at(i).id % 20 == 5)
             {
-                pub_cluster_grid_5.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_5.publish<nav_msgs::GridCells>(cluster_cells);
             }
             else if(clusters.at(i).id % 20 == 6)
             {
-                pub_cluster_grid_6.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_6.publish<nav_msgs::GridCells>(cluster_cells);
             }
             else if(clusters.at(i).id % 20 == 7)
             {
-                pub_cluster_grid_7.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_7.publish<nav_msgs::GridCells>(cluster_cells);
             }
             else if(clusters.at(i).id % 20 == 8)
             {
-                pub_cluster_grid_8.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_8.publish<nav_msgs::GridCells>(cluster_cells);
             }
             else if(clusters.at(i).id % 20 == 9)
             {
-                pub_cluster_grid_9.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_9.publish<nav_msgs::GridCells>(cluster_cells);
             }
-            
+
             if(clusters.at(i).id % 20 == 10)
             {
-                pub_cluster_grid_10.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_10.publish<nav_msgs::GridCells>(cluster_cells);
             }
             else if(clusters.at(i).id % 20 == 11)
             {
-                pub_cluster_grid_11.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_11.publish<nav_msgs::GridCells>(cluster_cells);
             }
             else if(clusters.at(i).id % 20 == 12)
             {
-                pub_cluster_grid_12.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_12.publish<nav_msgs::GridCells>(cluster_cells);
             }
             else if(clusters.at(i).id % 20 == 13)
             {
-                pub_cluster_grid_13.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_13.publish<nav_msgs::GridCells>(cluster_cells);
             }
             else if(clusters.at(i).id % 20 == 14)
             {
-                pub_cluster_grid_14.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_14.publish<nav_msgs::GridCells>(cluster_cells);
             }
             else if(clusters.at(i).id % 20 == 15)
             {
-                pub_cluster_grid_15.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_15.publish<nav_msgs::GridCells>(cluster_cells);
             }
             else if(clusters.at(i).id % 20 == 16)
             {
-                pub_cluster_grid_16.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_16.publish<nav_msgs::GridCells>(cluster_cells);
             }
             else if(clusters.at(i).id % 20 == 17)
             {
-                pub_cluster_grid_17.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_17.publish<nav_msgs::GridCells>(cluster_cells);
             }
             else if(clusters.at(i).id % 20 == 18)
             {
-                pub_cluster_grid_18.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_18.publish<nav_msgs::GridCells>(cluster_cells);
             }
             else if(clusters.at(i).id % 20 == 19)
             {
-                pub_cluster_grid_19.publish<nav_msgs::GridCells>(cluster_cells); 
+                pub_cluster_grid_19.publish<nav_msgs::GridCells>(cluster_cells);
             }
         }
     }
@@ -5034,10 +5091,10 @@ void ExplorationPlanner::visualize_Cluster_Cells()
 void ExplorationPlanner::visualize_Clusters()
 {
     ROS_INFO("Visualize clusters");
-    
+
     geometry_msgs::PolygonStamped cluster_polygon;
-    
-   
+
+
     for(int i= 0; i< clusters.size(); i++)
     {
         double upper_left_x, upper_left_y;
@@ -5104,11 +5161,11 @@ void ExplorationPlanner::visualize_Clusters()
         polygon_point.z = 0;
         cluster_polygon.polygon.points.push_back(polygon_point);
 
-        cluster_polygon.header.frame_id = move_base_frame;    
+        cluster_polygon.header.frame_id = move_base_frame;
         cluster_polygon.header.stamp = ros::Time::now();
         cluster_polygon.header.seq = i+1;
 
-        pub_clusters.publish<geometry_msgs::PolygonStamped>(cluster_polygon);  
+        pub_clusters.publish<geometry_msgs::PolygonStamped>(cluster_polygon);
         //break;// FIXME
     }
 }
@@ -5117,12 +5174,12 @@ void ExplorationPlanner::visualize_Clusters()
 void ExplorationPlanner::visualize_Frontiers()
 {
         visualization_msgs::MarkerArray markerArray;
-              
+
         for (int i = 0; i < frontiers.size(); i++)
         {
             visualization_msgs::Marker marker;
-            
-            marker.header.frame_id = move_base_frame;    
+
+            marker.header.frame_id = move_base_frame;
             marker.header.stamp = ros::Time::now();
             marker.header.seq = frontier_seq_number++;
             marker.ns = "my_namespace";
@@ -5139,43 +5196,43 @@ void ExplorationPlanner::visualize_Frontiers()
             marker.scale.x = 0.2;
             marker.scale.y = 0.2;
             marker.scale.z = 0.2;
-                        
+
             marker.color.a = 1.0;
-            
+
             if(frontiers.at(i).detected_by_robot == robot_name)
-            {                  
+            {
                 marker.color.r = 1.0;
                 marker.color.g = 0.0;
-                marker.color.b = 0.0;               
+                marker.color.b = 0.0;
             }
             if(frontiers.at(i).detected_by_robot == 1)
             {
                 marker.color.r = 0.0;
                 marker.color.g = 1.0;
                 marker.color.b = 0.0;
-            }  
+            }
             if(frontiers.at(i).detected_by_robot == 2)
             {
                 marker.color.r = 0.0;
                 marker.color.g = 0.0;
                 marker.color.b = 1.0;
-            }  
-            
-            markerArray.markers.push_back(marker);              
+            }
+
+            markerArray.markers.push_back(marker);
         }
-        
+
         pub_frontiers_points.publish <visualization_msgs::MarkerArray>(markerArray);
 }
 
 void ExplorationPlanner::visualize_visited_Frontiers()
 {
         visualization_msgs::MarkerArray markerArray;
-              
+
         for (int i = 0; i < visited_frontiers.size(); i++)
         {
             visualization_msgs::Marker marker;
-            
-            marker.header.frame_id = move_base_frame;    
+
+            marker.header.frame_id = move_base_frame;
             marker.header.stamp = ros::Time::now();
             marker.header.seq = i+1;
             marker.ns = "my_namespace";
@@ -5192,15 +5249,15 @@ void ExplorationPlanner::visualize_visited_Frontiers()
             marker.scale.x = 0.2;
             marker.scale.y = 0.2;
             marker.scale.z = 0.2;
-                        
+
             marker.color.a = 1.0;
-            
+
             if(visited_frontiers.at(i).detected_by_robot == robot_name)
-            {     
+            {
                 marker.color.a = 0.2;
                 marker.color.r = 1.0;
                 marker.color.g = 0.0;
-                marker.color.b = 0.0;               
+                marker.color.b = 0.0;
             }
             if(visited_frontiers.at(i).detected_by_robot == 1)
             {
@@ -5208,321 +5265,321 @@ void ExplorationPlanner::visualize_visited_Frontiers()
                 marker.color.r = 0.0;
                 marker.color.g = 1.0;
                 marker.color.b = 0.0;
-            }  
+            }
             if(visited_frontiers.at(i).detected_by_robot == 2)
             {
                 marker.color.a = 0.2;
                 marker.color.r = 0.0;
                 marker.color.g = 0.0;
                 marker.color.b = 1.0;
-            }  
+            }
             if(visited_frontiers.at(i).detected_by_robot == 3)
             {
                 marker.color.a = 0.2;
                 marker.color.r = 0.5;
                 marker.color.g = 0.0;
                 marker.color.b = 1.0;
-            }  
+            }
             if(visited_frontiers.at(i).detected_by_robot == 4)
             {
                 marker.color.a = 0.2;
                 marker.color.r = 0.0;
                 marker.color.g = 0.5;
                 marker.color.b = 1.0;
-            }  
+            }
             if(visited_frontiers.at(i).detected_by_robot == 5)
             {
                 marker.color.a = 0.2;
                 marker.color.r = 0.0;
                 marker.color.g = 0.0;
                 marker.color.b = 0.5;
-            }  
+            }
             if(visited_frontiers.at(i).detected_by_robot == 6)
             {
                 marker.color.a = 0.2;
                 marker.color.r = 0.5;
                 marker.color.g = 0.0;
                 marker.color.b = 0.5;
-            }  
+            }
             if(visited_frontiers.at(i).detected_by_robot == 7)
             {
                 marker.color.a = 0.2;
                 marker.color.r = 0.0;
                 marker.color.g = 0.5;
                 marker.color.b = 0.5;
-            }  
+            }
             if(visited_frontiers.at(i).detected_by_robot == 8)
             {
                 marker.color.a = 0.2;
                 marker.color.r = 0.0;
                 marker.color.g = 0.5;
                 marker.color.b = 0.0;
-            }  
+            }
             if(visited_frontiers.at(i).detected_by_robot == 9)
             {
                 marker.color.a = 0.2;
                 marker.color.r = 0.5;
                 marker.color.g = 0.5;
                 marker.color.b = 0.0;
-            }  
+            }
             if(visited_frontiers.at(i).detected_by_robot == 10)
             {
                 marker.color.a = 0.2;
                 marker.color.r = 0.5;
                 marker.color.g = 0.5;
                 marker.color.b = 0.5;
-            }  
-            markerArray.markers.push_back(marker);              
+            }
+            markerArray.markers.push_back(marker);
         }
-        
+
         pub_visited_frontiers_points.publish <visualization_msgs::MarkerArray>(markerArray);
 }
 
 
 void ExplorationPlanner::setupMapData() {
-           
-	if ((this->map_width_ != costmap_ros_->getCostmap()->getSizeInCellsX())
-			|| (this->map_height_ != costmap_ros_->getCostmap()->getSizeInCellsY())) {
-		this->deleteMapData();
 
-		map_width_ = costmap_ros_->getCostmap()->getSizeInCellsX();
-		map_height_ = costmap_ros_->getCostmap()->getSizeInCellsY();
-		num_map_cells_ = map_width_ * map_height_;
+    if ((this->map_width_ != costmap_ros_->getCostmap()->getSizeInCellsX())
+            || (this->map_height_ != costmap_ros_->getCostmap()->getSizeInCellsY())) {
+        this->deleteMapData();
 
-		ROS_INFO("Costmap size in cells: width:%d   height: %d   map_cells:%d",map_width_,map_height_,num_map_cells_);
+        map_width_ = costmap_ros_->getCostmap()->getSizeInCellsX();
+        map_height_ = costmap_ros_->getCostmap()->getSizeInCellsY();
+        num_map_cells_ = map_width_ * map_height_;
 
-		// initialize exploration_trans_array_, obstacle_trans_array_, goalMap and frontier_map_array_
+        ROS_INFO("Costmap size in cells: width:%d   height: %d   map_cells:%d",map_width_,map_height_,num_map_cells_);
+
+        // initialize exploration_trans_array_, obstacle_trans_array_, goalMap and frontier_map_array_
 //		exploration_trans_array_ = new unsigned int[num_map_cells_];
 //		obstacle_trans_array_ = new unsigned int[num_map_cells_];
 //		is_goal_array_ = new bool[num_map_cells_];
 //		frontier_map_array_ = new int[num_map_cells_];
 //		clearFrontiers();
 //		resetMaps();
-	}
+    }
 
-        
-	occupancy_grid_array_ = costmap_ros_->getCostmap()->getCharMap();
 
-	for (unsigned int i = 0; i < num_map_cells_; i++) {
+    occupancy_grid_array_ = costmap_ros_->getCostmap()->getCharMap();
 
-		countCostMapBlocks(i);
+    for (unsigned int i = 0; i < num_map_cells_; i++) {
 
-//	  if(occupancy_grid_array_[i] == costmap_2d::NO_INFORMATION || occupancy_grid_array_[i] == costmap_2d::INSCRIBED_INFLATED_OBSTACLE || occupancy_grid_array_[i] == costmap_2d::LETHAL_OBSTACLE || occupancy_grid_array_[i] == costmap_2d::FREE_SPACE)
-//	  {
-//	  }else
-//	  {
-//		  ROS_DEBUG("%d",(int)occupancy_grid_array_[i]);
-		  //occupancy_grid_array_[i] = '0'; // write 0 to the grid!
-//	  }
-	}
-	ROS_INFO("--------------------- Iterate through Costmap --------------------");
-	ROS_INFO("Free: %d  Inflated: %d  Lethal: %d  unknown: %d rest: %d", free,
-			inflated, lethal, unknown,
-			num_map_cells_ - (free + inflated + lethal + unknown));
-	ROS_INFO("------------------------------------------------------------------");
+        countCostMapBlocks(i);
+
+//    if(occupancy_grid_array_[i] == costmap_2d::NO_INFORMATION || occupancy_grid_array_[i] == costmap_2d::INSCRIBED_INFLATED_OBSTACLE || occupancy_grid_array_[i] == costmap_2d::LETHAL_OBSTACLE || occupancy_grid_array_[i] == costmap_2d::FREE_SPACE)
+//    {
+//    }else
+//    {
+//        ROS_DEBUG("%d",(int)occupancy_grid_array_[i]);
+          //occupancy_grid_array_[i] = '0'; // write 0 to the grid!
+//    }
+    }
+    ROS_INFO("--------------------- Iterate through Costmap --------------------");
+    ROS_INFO("Free: %d  Inflated: %d  Lethal: %d  unknown: %d rest: %d", free,
+            inflated, lethal, unknown,
+            num_map_cells_ - (free + inflated + lethal + unknown));
+    ROS_INFO("------------------------------------------------------------------");
         free_space = free;
 }
 
 void ExplorationPlanner::deleteMapData() {
-	if (exploration_trans_array_) {
-		delete[] exploration_trans_array_;
-		exploration_trans_array_ = 0;
-	}
-	if (obstacle_trans_array_) {
-		delete[] obstacle_trans_array_;
-		obstacle_trans_array_ = 0;
-	}
-	if (is_goal_array_) {
-		delete[] is_goal_array_;
-		is_goal_array_ = 0;
-	}
-	if (frontier_map_array_) {
-		delete[] frontier_map_array_;
-		frontier_map_array_ = 0;
-	}
+    if (exploration_trans_array_) {
+        delete[] exploration_trans_array_;
+        exploration_trans_array_ = 0;
+    }
+    if (obstacle_trans_array_) {
+        delete[] obstacle_trans_array_;
+        obstacle_trans_array_ = 0;
+    }
+    if (is_goal_array_) {
+        delete[] is_goal_array_;
+        is_goal_array_ = 0;
+    }
+    if (frontier_map_array_) {
+        delete[] frontier_map_array_;
+        frontier_map_array_ = 0;
+    }
 }
 
 void ExplorationPlanner::resetMaps() {
-	std::fill_n(exploration_trans_array_, num_map_cells_, INT_MAX);
-	std::fill_n(obstacle_trans_array_, num_map_cells_, INT_MAX);
-	std::fill_n(is_goal_array_, num_map_cells_, false);
+    std::fill_n(exploration_trans_array_, num_map_cells_, INT_MAX);
+    std::fill_n(obstacle_trans_array_, num_map_cells_, INT_MAX);
+    std::fill_n(is_goal_array_, num_map_cells_, false);
 }
 
 bool ExplorationPlanner::isSameFrontier(int frontier_point1,
-		int frontier_point2) {
-	unsigned int fx1, fy1;
-	unsigned int fx2, fy2;
-	double wfx1, wfy1;
-	double wfx2, wfy2;
-	costmap_.indexToCells(frontier_point1, fx1, fy1);
-	costmap_.indexToCells(frontier_point2, fx2, fy2);
-	costmap_.mapToWorld(fx1, fy1, wfx1, wfy1);
-	costmap_.mapToWorld(fx2, fy2, wfx2, wfy2);
+        int frontier_point2) {
+    unsigned int fx1, fy1;
+    unsigned int fx2, fy2;
+    double wfx1, wfy1;
+    double wfx2, wfy2;
+    costmap_.indexToCells(frontier_point1, fx1, fy1);
+    costmap_.indexToCells(frontier_point2, fx2, fy2);
+    costmap_.mapToWorld(fx1, fy1, wfx1, wfy1);
+    costmap_.mapToWorld(fx2, fy2, wfx2, wfy2);
 
-	double dx = wfx1 - wfx2;
-	double dy = wfy1 - wfy2;
+    double dx = wfx1 - wfx2;
+    double dy = wfy1 - wfy2;
 
-	if ((dx * dx) + (dy * dy)
-			< (p_same_frontier_dist_ * p_same_frontier_dist_)) {
-		return true;
-	}
-	return false;
+    if ((dx * dx) + (dy * dy)
+            < (p_same_frontier_dist_ * p_same_frontier_dist_)) {
+        return true;
+    }
+    return false;
 }
 
 // Used to generate direction for frontiers
 double ExplorationPlanner::getYawToUnknown(int point) {
-	int adjacentPoints[8];
-	getAdjacentPoints(point, adjacentPoints);
+    int adjacentPoints[8];
+    getAdjacentPoints(point, adjacentPoints);
 
-	int max_obs_idx = 0;
+    int max_obs_idx = 0;
 
-	for (int i = 0; i < 8; ++i) {
-		if (isValid(adjacentPoints[i])) {
-			if (occupancy_grid_array_[adjacentPoints[i]]
-					== costmap_2d::NO_INFORMATION) {
-				if (obstacle_trans_array_[adjacentPoints[i]]
-						> obstacle_trans_array_[adjacentPoints[max_obs_idx]]) {
-					max_obs_idx = i;
-				}
-			}
-		}
-	}
+    for (int i = 0; i < 8; ++i) {
+        if (isValid(adjacentPoints[i])) {
+            if (occupancy_grid_array_[adjacentPoints[i]]
+                    == costmap_2d::NO_INFORMATION) {
+                if (obstacle_trans_array_[adjacentPoints[i]]
+                        > obstacle_trans_array_[adjacentPoints[max_obs_idx]]) {
+                    max_obs_idx = i;
+                }
+            }
+        }
+    }
 
-	int orientationPoint = adjacentPoints[max_obs_idx];
-	unsigned int sx, sy, gx, gy;
-	costmap_.indexToCells((unsigned int) point, sx, sy);
-	costmap_.indexToCells((unsigned int) orientationPoint, gx, gy);
-	int x = gx - sx;
-	int y = gy - sy;
-	double yaw = std::atan2(y, x);
+    int orientationPoint = adjacentPoints[max_obs_idx];
+    unsigned int sx, sy, gx, gy;
+    costmap_.indexToCells((unsigned int) point, sx, sy);
+    costmap_.indexToCells((unsigned int) orientationPoint, gx, gy);
+    int x = gx - sx;
+    int y = gy - sy;
+    double yaw = std::atan2(y, x);
 
-	return yaw;
+    return yaw;
 
 }
 
 int ExplorationPlanner::isFrontier(int point) {
 
-   
-	if (isFree(point)) {
-            
-		/*
-		 * The point is a either a obstacle or a point with not enough
-		 * information about
-		 * Therefore, check if the point is surrounded by other NO_INFORMATION
-		 * points. Then further space to explore is found ---> frontier
-		 */
-		//int Neighbours = 0;
-		//int points[((int)pow(8,Neighbours+1))+8]; // NEIGHBOURS points, each containing 8 adjacent points
-		int no_inf_count = 0;
-		int inscribed_count = 0;
-		int adjacent_points[16];
-		/*
-		 * Now take one point and lookup all adjacent points (surrounding points).
-		 * The variable adjacentPoints contains all neighboring point (up, right, left ...)
-		 */
 
-		/*
-		 ROS_DEBUG("Adjacent Point: %d",adjacentPoints[0]);
-		 ROS_DEBUG("Adjacent Point: %d",adjacentPoints[1]);
-		 ROS_DEBUG("Adjacent Point: %d",adjacentPoints[2]);
-		 ROS_DEBUG("Adjacent Point: %d",adjacentPoints[3]);
-		 ROS_DEBUG("Adjacent Point: %d",adjacentPoints[4]);
-		 ROS_DEBUG("Adjacent Point: %d",adjacentPoints[5]);
-		 ROS_DEBUG("Adjacent Point: %d",adjacentPoints[6]);
-		 ROS_DEBUG("Adjacent Point: %d",adjacentPoints[7]);
-		 */
+    if (isFree(point)) {
 
-		//histogram[(int)occupancy_grid_array_[point]]++;
-                
-		if ((int) occupancy_grid_array_[point] == costmap_2d::FREE_SPACE)//<= threshold_free)
-		{
-			getAdjacentPoints(point, adjacent_points);
-			for (int i = 0; i < 16; i++) // length of adjacent_points array
-			{
-				
-				if (occupancy_grid_array_[adjacent_points[i]] == costmap_2d::NO_INFORMATION) {
-					no_inf_count++;	
+        /*
+         * The point is a either a obstacle or a point with not enough
+         * information about
+         * Therefore, check if the point is surrounded by other NO_INFORMATION
+         * points. Then further space to explore is found ---> frontier
+         */
+        //int Neighbours = 0;
+        //int points[((int)pow(8,Neighbours+1))+8]; // NEIGHBOURS points, each containing 8 adjacent points
+        int no_inf_count = 0;
+        int inscribed_count = 0;
+        int adjacent_points[16];
+        /*
+         * Now take one point and lookup all adjacent points (surrounding points).
+         * The variable adjacentPoints contains all neighboring point (up, right, left ...)
+         */
+
+        /*
+         ROS_DEBUG("Adjacent Point: %d",adjacentPoints[0]);
+         ROS_DEBUG("Adjacent Point: %d",adjacentPoints[1]);
+         ROS_DEBUG("Adjacent Point: %d",adjacentPoints[2]);
+         ROS_DEBUG("Adjacent Point: %d",adjacentPoints[3]);
+         ROS_DEBUG("Adjacent Point: %d",adjacentPoints[4]);
+         ROS_DEBUG("Adjacent Point: %d",adjacentPoints[5]);
+         ROS_DEBUG("Adjacent Point: %d",adjacentPoints[6]);
+         ROS_DEBUG("Adjacent Point: %d",adjacentPoints[7]);
+         */
+
+        //histogram[(int)occupancy_grid_array_[point]]++;
+
+        if ((int) occupancy_grid_array_[point] == costmap_2d::FREE_SPACE)//<= threshold_free)
+        {
+            getAdjacentPoints(point, adjacent_points);
+            for (int i = 0; i < 16; i++) // length of adjacent_points array
+            {
+
+                if (occupancy_grid_array_[adjacent_points[i]] == costmap_2d::NO_INFORMATION) {
+                    no_inf_count++;
 //                                        ROS_DEBUG("No information found!");
-				} 
+                }
                                 else if (occupancy_grid_array_[adjacent_points[i]] == costmap_2d::LETHAL_OBSTACLE) {
-					/*
-					 * Do not break here ... In some scenarios it may happen that unknown and free space
-					 * form a border, but if just a small corridor is available there, it would not be
-					 * detected as frontier, since even one neighboring block is an inflated block.
-					 * Therefore do nothing, if even one unknown block is a neighbor of an free space
-					 * block, then it is a frontier!
-					 */
+                    /*
+                     * Do not break here ... In some scenarios it may happen that unknown and free space
+                     * form a border, but if just a small corridor is available there, it would not be
+                     * detected as frontier, since even one neighboring block is an inflated block.
+                     * Therefore do nothing, if even one unknown block is a neighbor of an free space
+                     * block, then it is a frontier!
+                     */
 
-					//inscribed_count++;
+                    //inscribed_count++;
 //                                        ROS_DEBUG("Obstacle found");
-					return(0);
-				}
-			}
+                    return(0);
+                }
+            }
 
-			/*
-			 * Count the number of lethal obstacle (unknown space also included
-			 * here). If an inflated obstacle was detected ... the point is not
-			 * a possible frontier and should no longer be considered.
-			 * Otherwise, when all surronding blocks --> 64+7 are unknown just the
-			 * one in the middle is free space, then we found a frontier!!
-			 * On every found frontier, true is returned
-			 */
-			if (no_inf_count > 0)
-			{
-				/*
-				 * Above a adjacent Point is taken and compared with NO_INFORMATION.
-				 * If the point contains no information, the next surrounding point from that point
-				 * is taken and again compared with NO_INFORMATION. If there are at least
-				 * two points with no information surrounding a no information point, then return true!
-				 * (at least two points with no information means that there is sufficient space
-				 * with not enough information about)
-				 */
+            /*
+             * Count the number of lethal obstacle (unknown space also included
+             * here). If an inflated obstacle was detected ... the point is not
+             * a possible frontier and should no longer be considered.
+             * Otherwise, when all surronding blocks --> 64+7 are unknown just the
+             * one in the middle is free space, then we found a frontier!!
+             * On every found frontier, true is returned
+             */
+            if (no_inf_count > 0)
+            {
+                /*
+                 * Above a adjacent Point is taken and compared with NO_INFORMATION.
+                 * If the point contains no information, the next surrounding point from that point
+                 * is taken and again compared with NO_INFORMATION. If there are at least
+                 * two points with no information surrounding a no information point, then return true!
+                 * (at least two points with no information means that there is sufficient space
+                 * with not enough information about)
+                 */
 
                             //return(backoff(point));
 ;                           return(point);
-			}
-		}
-	}
-	return(0);
+            }
+        }
+    }
+    return(0);
 }
 
 
 int ExplorationPlanner::backoff (int point)
 {
-    				if(occupancy_grid_array_[up(point)] == costmap_2d::NO_INFORMATION && occupancy_grid_array_[left(point)] == costmap_2d::NO_INFORMATION)
-				{
-					return(downright(downright(downright(point))));
-				}
-				if(occupancy_grid_array_[up(point)] == costmap_2d::NO_INFORMATION && occupancy_grid_array_[right(point)] == costmap_2d::NO_INFORMATION)
-				{
-					return(downleft(downleft(downleft(point))));
-				}
-				if(occupancy_grid_array_[down(point)] == costmap_2d::NO_INFORMATION && occupancy_grid_array_[left(point)] == costmap_2d::NO_INFORMATION)
-				{
-					return(upright(upright(upright(point))));
-				}
-				if(occupancy_grid_array_[down(point)] == costmap_2d::NO_INFORMATION && occupancy_grid_array_[right(point)] == costmap_2d::NO_INFORMATION)
-				{
-					return(upleft(upleft(upleft(point))));
-				}
+                    if(occupancy_grid_array_[up(point)] == costmap_2d::NO_INFORMATION && occupancy_grid_array_[left(point)] == costmap_2d::NO_INFORMATION)
+                {
+                    return(downright(downright(downright(point))));
+                }
+                if(occupancy_grid_array_[up(point)] == costmap_2d::NO_INFORMATION && occupancy_grid_array_[right(point)] == costmap_2d::NO_INFORMATION)
+                {
+                    return(downleft(downleft(downleft(point))));
+                }
+                if(occupancy_grid_array_[down(point)] == costmap_2d::NO_INFORMATION && occupancy_grid_array_[left(point)] == costmap_2d::NO_INFORMATION)
+                {
+                    return(upright(upright(upright(point))));
+                }
+                if(occupancy_grid_array_[down(point)] == costmap_2d::NO_INFORMATION && occupancy_grid_array_[right(point)] == costmap_2d::NO_INFORMATION)
+                {
+                    return(upleft(upleft(upleft(point))));
+                }
 
 
-				if(occupancy_grid_array_[right(point)] == costmap_2d::NO_INFORMATION)
-				{
-					return(left(left(left(point))));
-				}
-				if(occupancy_grid_array_[down(point)] == costmap_2d::NO_INFORMATION)
-				{
-					return(up(up(up(point))));
-				}
-				if(occupancy_grid_array_[left(point)] == costmap_2d::NO_INFORMATION)
-				{
-					return(right(right(right(point))));
-				}
-				if(occupancy_grid_array_[up(point)] == costmap_2d::NO_INFORMATION)
-				{
-					return(down(down(down(point))));
-				}
+                if(occupancy_grid_array_[right(point)] == costmap_2d::NO_INFORMATION)
+                {
+                    return(left(left(left(point))));
+                }
+                if(occupancy_grid_array_[down(point)] == costmap_2d::NO_INFORMATION)
+                {
+                    return(up(up(up(point))));
+                }
+                if(occupancy_grid_array_[left(point)] == costmap_2d::NO_INFORMATION)
+                {
+                    return(right(right(right(point))));
+                }
+                if(occupancy_grid_array_[up(point)] == costmap_2d::NO_INFORMATION)
+                {
+                    return(down(down(down(point))));
+                }
 
 //				if(occupancy_grid_array_[upleft(point)] == costmap_2d::NO_INFORMATION)
 //				{
@@ -5540,252 +5597,251 @@ int ExplorationPlanner::backoff (int point)
 //				{
 //					return(upright(upright(point)));
 //				}
-				else
-				{
-					return(point);
-				}
+                else
+                {
+                    return(point);
+                }
 }
 
 bool ExplorationPlanner::isFrontierReached(int point) {
 
-	tf::Stamped < tf::Pose > robotPose;
-	if (!costmap_ros_->getRobotPose(robotPose)) {
-		ROS_WARN("[isFrontierReached]: Failed to get RobotPose");
-	}
-	geometry_msgs::PoseStamped robotPoseMsg;
-	tf::poseStampedTFToMsg(robotPose, robotPoseMsg);
+    tf::Stamped < tf::Pose > robotPose;
+    if (!costmap_ros_->getRobotPose(robotPose)) {
+        ROS_WARN("[isFrontierReached]: Failed to get RobotPose");
+    }
+    geometry_msgs::PoseStamped robotPoseMsg;
+    tf::poseStampedTFToMsg(robotPose, robotPoseMsg);
 
-	unsigned int fx, fy;
-	double wfx, wfy;
-	costmap_.indexToCells(point, fx, fy);
-	costmap_.mapToWorld(fx, fy, wfx, wfy);
+    unsigned int fx, fy;
+    double wfx, wfy;
+    costmap_.indexToCells(point, fx, fy);
+    costmap_.mapToWorld(fx, fy, wfx, wfy);
 
-	double dx = robotPoseMsg.pose.position.x - wfx;
-	double dy = robotPoseMsg.pose.position.y - wfy;
+    double dx = robotPoseMsg.pose.position.x - wfx;
+    double dy = robotPoseMsg.pose.position.y - wfy;
 
-	if ((dx * dx) + (dy * dy)
-			< (p_dist_for_goal_reached_ * p_dist_for_goal_reached_)) {
-		//ROS_DEBUG("[isFrontierReached]: frontier is within the squared range of distance: %f m", p_dist_for_goal_reached_);
-		return true;
-	}
+    if ((dx * dx) + (dy * dy)
+            < (p_dist_for_goal_reached_ * p_dist_for_goal_reached_)) {
+        //ROS_DEBUG("[isFrontierReached]: frontier is within the squared range of distance: %f m", p_dist_for_goal_reached_);
+        return true;
+    }
 
-	return false;
+    return false;
 
 }
 
 inline void ExplorationPlanner::getAdjacentPoints(int point, int points[]) {
 
-	/*
-	 * Get all surrounding neighbors and the neighbors of those.
-	 */
+    /*
+     * Get all surrounding neighbors and the neighbors of those.
+     */
 
-	/*
-	 * 		ooo ooo
-	 *
-	 */
+    /*
+     *      ooo ooo
+     *
+     */
 
-	/*
-	 points[0] = left(point);
-	 points[1] = right(point);
-	 points[2] = left(points[0]);
-	 points[3] = right(points[1]);
-	 points[4] = left(points[2]);
-	 points[5] = right(points[3]);
-	 points[6] = left(points[4]);
-	 points[7] = right(points[5]);
-	 */
+    /*
+     points[0] = left(point);
+     points[1] = right(point);
+     points[2] = left(points[0]);
+     points[3] = right(points[1]);
+     points[4] = left(points[2]);
+     points[5] = right(points[3]);
+     points[6] = left(points[4]);
+     points[7] = right(points[5]);
+     */
 
-	/*
-	 *            o
-	 *          o   o
-	 *            o
-	 *
-	 */
-       
+    /*
+     *            o
+     *          o   o
+     *            o
+     *
+     */
+
         /*
-	points[0] = left(point);
-	points[1] = up(point);
-	points[2] = right(point);
-	points[3] = down(point);
+    points[0] = left(point);
+    points[1] = up(point);
+    points[2] = right(point);
+    points[3] = down(point);
         */
-    
-	/*
-	 *          o o o
-	 *          o   o
-	 *          o o o
-	 *
-	 */
 
-	
-	 points[0] = left(point);
-	 points[1] = up(point);
-	 points[2] = right(point);
-	 points[3] = down(point);
-	 points[4] = upleft(point);
-	 points[5] = upright(point);
-	 points[6] = downright(point);
-	 points[7] = downleft(point);
-	 
-	/*
-	 *        *   *   *
-	 *          o o o
-	 *        * o   o *
-	 *          o o o
-	 *        *   *   *
-	 */
-	
-	 points[8] =  left(points[0]);
-	 points[9] =  up(points[1]);
-	 points[10] = right(points[2]);
-	 points[11] = down(points[3]);
-	 points[12] = upleft(points[4]);
-	 points[13] = upright(points[5]);
-	 points[14] = downright(points[6]);
-	 points[15] = downleft(points[7]);
-	 
+    /*
+     *          o o o
+     *          o   o
+     *          o o o
+     *
+     */
 
-	/*
-	 *        * + * + *
-	 *        + o o o +
-	 *        * o   o *
-	 *        + o o o +
-	 *        * + * + *
-	 */
-	/*
-	 points[16] = up(points[4]);
-	 points[17] = up(points[5]);
-	 points[18] = right(points[5]);
-	 points[19] = right(points[6]);
-	 points[20] = down(points[6]);
-	 points[21] = down(points[7]);
-	 points[22] = left(points[7]);
-	 points[23] = left(points[4]);
-	 */
 
-	/*
-	 *      #     #     #
-	 *        *   *   *
-	 *          o o o
-	 *      # * o   o * #
-	 *          o o o
-	 *        *   *   *
-	 *      #     #     #
-	 */
-	/*
-	 points[16] = left(points[8]);
-	 points[17] = up(points[9]);
-	 points[18] = right(points[10]);
-	 points[19] = down(points[11]);
-	 points[20] = upleft(points[12]);
-	 points[21] = upright(points[13]);
-	 points[22] = downright(points[14]);
-	 points[23] = downleft(points[15]);
-	 */
+     points[0] = left(point);
+     points[1] = up(point);
+     points[2] = right(point);
+     points[3] = down(point);
+     points[4] = upleft(point);
+     points[5] = upright(point);
+     points[6] = downright(point);
+     points[7] = downleft(point);
+
+    /*
+     *        *   *   *
+     *          o o o
+     *        * o   o *
+     *          o o o
+     *        *   *   *
+     */
+
+     points[8] =  left(points[0]);
+     points[9] =  up(points[1]);
+     points[10] = right(points[2]);
+     points[11] = down(points[3]);
+     points[12] = upleft(points[4]);
+     points[13] = upright(points[5]);
+     points[14] = downright(points[6]);
+     points[15] = downleft(points[7]);
+
+
+    /*
+     *        * + * + *
+     *        + o o o +
+     *        * o   o *
+     *        + o o o +
+     *        * + * + *
+     */
+    /*
+     points[16] = up(points[4]);
+     points[17] = up(points[5]);
+     points[18] = right(points[5]);
+     points[19] = right(points[6]);
+     points[20] = down(points[6]);
+     points[21] = down(points[7]);
+     points[22] = left(points[7]);
+     points[23] = left(points[4]);
+     */
+
+    /*
+     *      #     #     #
+     *        *   *   *
+     *          o o o
+     *      # * o   o * #
+     *          o o o
+     *        *   *   *
+     *      #     #     #
+     */
+    /*
+     points[16] = left(points[8]);
+     points[17] = up(points[9]);
+     points[18] = right(points[10]);
+     points[19] = down(points[11]);
+     points[20] = upleft(points[12]);
+     points[21] = upright(points[13]);
+     points[22] = downright(points[14]);
+     points[23] = downleft(points[15]);
+     */
 }
 
-bool ExplorationPlanner::countCostMapBlocks(int point) {	
-       
+bool ExplorationPlanner::countCostMapBlocks(int point) {
+
        if (occupancy_grid_array_[point] == costmap_2d::NO_INFORMATION) {
 //		ROS_DEBUG("[isFree] NO_INFORMATION");
-		unknown++;
-		return true;
-	} else if ((int) occupancy_grid_array_[point] == costmap_2d::FREE_SPACE) {
-		free++;
+        unknown++;
+        return true;
+    } else if ((int) occupancy_grid_array_[point] == costmap_2d::FREE_SPACE) {
+        free++;
 //		ROS_DEBUG("[isFree] FREE SPACE FOUND");
-		return true;
-	}
+        return true;
+    }
 
-	else if ((int) occupancy_grid_array_[point] == costmap_2d::LETHAL_OBSTACLE) {
-		lethal++;
+    else if ((int) occupancy_grid_array_[point] == costmap_2d::LETHAL_OBSTACLE) {
+        lethal++;
 //		ROS_DEBUG("[isFree] LETHAL OBSTACLE FOUND");
-		return true;
-	} else if ((int) occupancy_grid_array_[point] == costmap_2d::INSCRIBED_INFLATED_OBSTACLE) {
-		inflated++;
+        return true;
+    } else if ((int) occupancy_grid_array_[point] == costmap_2d::INSCRIBED_INFLATED_OBSTACLE) {
+        inflated++;
 //		ROS_DEBUG("[isFree] INSCRIBED INFLATED OBSTACLE FOUND");
-		return true;
-	} else 
+        return true;
+    } else
         {
-		int undefined = (unsigned char) occupancy_grid_array_[point];
-		// An obstacle was found. This is no free space, so a FALSE is returned
+        int undefined = (unsigned char) occupancy_grid_array_[point];
+        // An obstacle was found. This is no free space, so a FALSE is returned
 //		ROS_DEBUG("undefined value: %d", undefined);
-		return true;
-	}
-	return false;
+        return true;
+    }
+    return false;
 }
 
 bool ExplorationPlanner::isFree(int point) {
-	if (isValid(point)) {
+    if (isValid(point)) {
 
-		return true;
-	} else {
-		ROS_ERROR("Point is not valid! Reason: negative number ");
-	}
-	return false;
+        return true;
+    } else {
+        ROS_ERROR("Point is not valid! Reason: negative number ");
+    }
+    return false;
 }
 
 inline bool ExplorationPlanner::isValid(int point) {
-	return (point >= 0);
+    return (point >= 0);
 }
 
 void ExplorationPlanner::clearFrontiers() {
-	std::fill_n(frontier_map_array_, num_map_cells_, 0);
+    std::fill_n(frontier_map_array_, num_map_cells_, 0);
 }
 
 inline int ExplorationPlanner::left(int point) {
-	// only go left if no index error and if current point is not already on the left boundary
-	if ((point % map_width_ != 0)) {
-		return point - 1;
-	}
-	return -1;
+    // only go left if no index error and if current point is not already on the left boundary
+    if ((point % map_width_ != 0)) {
+        return point - 1;
+    }
+    return -1;
 }
 
 inline int ExplorationPlanner::upleft(int point) {
-	if ((point % map_width_ != 0) && (point >= (int) map_width_)) {
-		return point - map_width_ - 1;
-	}
-	return -1;
+    if ((point % map_width_ != 0) && (point >= (int) map_width_)) {
+        return point - map_width_ - 1;
+    }
+    return -1;
 
 }
 inline int ExplorationPlanner::up(int point) {
-	if (point >= (int) map_width_) {
-		return point - map_width_;
-	}
-	return -1;
+    if (point >= (int) map_width_) {
+        return point - map_width_;
+    }
+    return -1;
 }
 inline int ExplorationPlanner::upright(int point) {
-	if ((point >= (int) map_width_) && ((point + 1) % (int) map_width_ != 0)) {
-		return point - map_width_ + 1;
-	}
-	return -1;
+    if ((point >= (int) map_width_) && ((point + 1) % (int) map_width_ != 0)) {
+        return point - map_width_ + 1;
+    }
+    return -1;
 }
 inline int ExplorationPlanner::right(int point) {
-	if ((point + 1) % map_width_ != 0) {
-		return point + 1;
-	}
-	return -1;
+    if ((point + 1) % map_width_ != 0) {
+        return point + 1;
+    }
+    return -1;
 
 }
 inline int ExplorationPlanner::downright(int point) {
-	if (((point + 1) % map_width_ != 0)
-			&& ((point / map_width_) < (map_width_ - 1))) {
-		return point + map_width_ + 1;
-	}
-	return -1;
+    if (((point + 1) % map_width_ != 0)
+            && ((point / map_width_) < (map_width_ - 1))) {
+        return point + map_width_ + 1;
+    }
+    return -1;
 
 }
 inline int ExplorationPlanner::down(int point) {
-	if ((point / map_width_) < (map_width_ - 1)) {
-		return point + map_width_;
-	}
-	return -1;
+    if ((point / map_width_) < (map_width_ - 1)) {
+        return point + map_width_;
+    }
+    return -1;
 
 }
 inline int ExplorationPlanner::downleft(int point) {
-	if (((point / map_width_) < (map_width_ - 1))
-			&& (point % map_width_ != 0)) {
-		return point + map_width_ - 1;
-	}
-	return -1;
+    if (((point / map_width_) < (map_width_ - 1))
+            && (point % map_width_ != 0)) {
+        return point + map_width_ - 1;
+    }
+    return -1;
 
 }
-

--- a/explorer/src/explorer.cpp
+++ b/explorer/src/explorer.cpp
@@ -244,543 +244,544 @@ public:
 	}
 
 
-	void explore() 
+    void explore()
+    {
+        /*
+         * Sleep is required to get the actual
+         * costmap updated with obstacle and inflated
+         * obstacle information. This is rquired for the
+         * first time explore() is called.
+         */
+        ROS_DEBUG("Sleeping 5s for costmaps to be updated.");
+        geometry_msgs::Twist twi;
+        //should be a parameter!! only for testing on Wed/17/9/14
+        ros::Publisher twi_publisher = nh.advertise<geometry_msgs::Twist>("/Rosaria/cmd_vel", 3);
+        twi.angular.z = 0.75;
+        twi_publisher.publish(twi);
+        ros::Duration(5.0).sleep();
+        twi.angular.z = -0.75; // so that we like didn't do anything ;)
+        twi_publisher.publish(twi);
+        /*
+         * START TAKING THE TIME DURING EXPLORATION
+         */
+        time_start = ros::Time::now();
+        while (exploration_finished == false)
         {
-		/*
-		 * Sleep is required to get the actual 
-		 * costmap updated with obstacle and inflated 
-		 * obstacle information. This is rquired for the
-		 * first time explore() is called.
-		 */
-		ROS_DEBUG("Sleeping 5s for costmaps to be updated.");
-                geometry_msgs::Twist twi;
-                //should be a parameter!! only for testing on Wed/17/9/14
-                ros::Publisher twi_publisher = nh.advertise<geometry_msgs::Twist>("/Rosaria/cmd_vel",3);
-                twi.angular.z = 0.75;
-                twi_publisher.publish(twi);
-                ros::Duration(5.0).sleep();
-		twi.angular.z = -0.75; //so that we like didn't do anything ;)
-                twi_publisher.publish(twi);
+            ROS_DEBUG("exploration now finished, continue");
+            if (Simulation == false)
+            {
                 /*
-                 * START TAKING THE TIME DURING EXPLORATION     
+                 * *****************************************************
+                 * FRONTIER DETERMINATION
+                 * *****************************************************
                  */
-                time_start = ros::Time::now();
-                
-                
-		while (exploration_finished == false) 
+
+                std::vector<double> final_goal;
+                std::vector<double> backoffGoal;
+                std::vector<std::string> robot_str;
+
+                bool backoff_sucessfull = false,
+                     navigate_to_goal = false;
+                bool negotiation;
+                int count = 0;
+
+                ROS_INFO("****************** EXPLORE ******************");
+
+                /*
+                 * Use mutex to lock the critical section (access to the costmap)
+                 * since rosspin tries to update the costmap continuously
+                 */
+                costmap_mutex.lock();
+
+                exploration->transformToOwnCoordinates_frontiers();
+                exploration->transformToOwnCoordinates_visited_frontiers();
+
+                // ros::Duration(1.0).sleep();
+                exploration->initialize_planner("exploration planner", costmap2d_local, costmap2d_global);
+                exploration->findFrontiers();
+                // exploration->printFrontiers();
+
+                exploration->clearVisitedFrontiers();
+                exploration->clearUnreachableFrontiers();
+                exploration->clearSeenFrontiers(costmap2d_global);
+
+                costmap_mutex.unlock();
+
+                exploration->publish_frontier_list();
+                exploration->publish_visited_frontier_list();
+
+                ros::Duration(1).sleep();
+                exploration->publish_frontier_list();
+                exploration->publish_visited_frontier_list();
+
+                /*
+                 * Sleep to ensure that frontiers are exchanged
+                 */
+                ros::Duration(1).sleep();
+
+                /*
+                 * *****************************************************
+                 * FRONTIER SELECTION
+                 * *****************************************************
+                 */
+
+                /*********** EXPLORATION STRATEGY ************
+                 * 0 ... Navigate to nearest frontier TRAVEL PATH
+                 * 1 ... Navigate using auctioning with cluster selection using
+                 *       NEAREST selection (Kuhn-Munkres)
+                 * 2 ... Navigate to furthest frontier
+                 * 3 ... Navigate to nearest frontier EUCLIDEAN DISTANCE
+                 * 4 ... Navigate to random Frontier
+                 * 5 ... Cluster frontiers, then navigate to nearest cluster
+                 *       using EUCLIDEAN DISTANCE (with and without
+                 *       negotiation)
+                 * 6 ... Cluster frontiers, then navigate to random cluster
+                 *       (with and without negotiation)
+                 */
+
+                /******************** SORT *******************
+                 * Choose which strategy to take.
+                 * 1 ... Sort the buffer from furthest to nearest frontier
+                 * 2 ... Sort the buffer from nearest to furthest frontier, normalized to the
+                 *       robots actual position (EUCLIDEAN DISTANCE)
+                 * 3 ... Sort the last 10 entries to shortest TRAVEL PATH
+                 * 4 ... Sort all cluster elements from nearest to furthest (EUCLIDEAN DISTANCE)
+                 */
+                if (frontier_selection < 0 || frontier_selection > 6)
                 {
-			ROS_DEBUG("exploration now finished, continue");
-                    Simulation == false; 
-                    if(Simulation == false)
+                    ROS_FATAL("You selected an invalid exploration strategy. Please make sure to set it in the interval [0,6]. The current value is %d.", frontier_selection);
+                }
+                if (frontier_selection == 2)
+                {
+                    exploration->sort(1);
+                    /*
+                     * Choose which strategy to take.
+                     * 1 ... least to first goal in list
+                     * 2 ... first to last goal in list
+                     *
+                     * Determine_goal() takes world coordinates stored in
+                     * the frontiers list(which contain every found frontier with sufficient
+                     * spacing in between) and returns the most attractive one, based on the
+                     * above defined strategies.
+                     */
+                    while (true)
+                    {
+                        goal_determined = exploration->determine_goal(1, &final_goal, count, 0, &robot_str);
+                        if (goal_determined == false)
+                        {
+                            break;
+                        }
+                        else
+                        {
+                            //negotiation = exploration->negotiate_Frontier(final_goal.at(0),final_goal.at(1),final_goal.at(2),final_goal.at(3),-1);
+                            negotiation = true;
+                            if (negotiation == true)
+                            {
+                                break;
+                            }
+                            count++;
+                        }
+                    }
+                }
+                else if (frontier_selection == 3)
+                {
+                    exploration->sort(2);
+
+                    while (true)
+                    {
+                        goal_determined = exploration->determine_goal(2, &final_goal, count, 0, &robot_str);
+                        if (goal_determined == false)
+                        {
+                            break;
+                        }
+                        else
+                        {
+                            //negotiation = exploration->negotiate_Frontier(final_goal.at(0),final_goal.at(1),final_goal.at(2),final_goal.at(3),-1);
+                            negotiation = true;
+                            if (negotiation == true)
+                            {
+                                break;
+                            }
+                            count++;
+                        }
+                    }
+                }
+                else if (frontier_selection == 0)
+                {
+                    exploration->sort(2);
+                    exploration->sort(3);
+
+                    while (true)
+                    {
+                        goal_determined = exploration->determine_goal(2, &final_goal, count, 0, &robot_str);
+                        ROS_DEBUG("Goal_determined: %d   counter: %d", goal_determined, count);
+                        if (goal_determined == false)
+                        {
+                            break;
+                        }
+                        else
+                        {
+                            //negotiation = exploration->negotiate_Frontier(final_goal.at(0),final_goal.at(1),final_goal.at(2),final_goal.at(3),-1);
+                            negotiation = true;
+                            if (negotiation == true)
+                            {
+                                break;
+                            }
+                            count++;
+                        }
+                    }
+                }
+                else if (frontier_selection == 4)
+                {
+                    while (true)
+                    {
+                        goal_determined = exploration->determine_goal(3, &final_goal, count, 0, &robot_str);
+                        ROS_DEBUG("Goal_determined: %d   counter: %d", goal_determined, count);
+                        if (goal_determined == false)
+                        {
+                            break;
+                        }
+                        else
+                        {
+                            //negotiation = exploration->negotiate_Frontier(final_goal.at(0),final_goal.at(1),final_goal.at(2),final_goal.at(3),-1);
+                            negotiation = true;
+                            if (negotiation == true)
+                            {
+                                break;
+                            }
+                            count++;
+                        }
+                    }
+                }
+                else if (frontier_selection == 5)
+                {
+                    if (cluster_initialize_flag == true)
+                    {
+                        exploration->clearVisitedAndSeenFrontiersFromClusters();
+                    }
+                    else
                     {
                         /*
-                         * *****************************************************
-                         * FRONTIER DETERMINATION
-                         * *****************************************************
+                         * This is necessary for the first run
                          */
-
-                            std::vector<double> final_goal;
-                            std::vector<double> backoffGoal;
-                            std::vector<std::string> robot_str;
-                            
-                            bool backoff_sucessfull = false, navigate_to_goal = false;
-                            bool negotiation;
-                            int count = 0;
-
-                            ROS_INFO("****************** EXPLORE ******************");
-
-                            /*
-                             * Use mutex to lock the critical section (access to the costmap)
-                             * since rosspin tries to update the costmap continuously
-                             */
-                            costmap_mutex.lock();
-
-                            exploration->transformToOwnCoordinates_frontiers();
-                            exploration->transformToOwnCoordinates_visited_frontiers();
-
-//    			    ros::Duration(1.0).sleep();
-                            exploration->initialize_planner("exploration planner", costmap2d_local, costmap2d_global);
-                            exploration->findFrontiers();
-//                            exploration->printFrontiers();
-                          
-                            exploration->clearVisitedFrontiers();                       
-                            exploration->clearUnreachableFrontiers();
-                            exploration->clearSeenFrontiers(costmap2d_global);       
-
-                            costmap_mutex.unlock();
-
-                            exploration->publish_frontier_list();  
-                            exploration->publish_visited_frontier_list();  
-
-                            ros::Duration(1).sleep();
-                            exploration->publish_frontier_list();  
-                            exploration->publish_visited_frontier_list();  
-
-                            /*
-                             * Sleep to ensure that frontiers are exchanged
-                             */
-                            ros::Duration(1).sleep();
-                           
-                            /*
-                             * *****************************************************
-                             * FRONTIER SELECTION
-                             * *****************************************************
-                             */
- 
-                            /*********** EXPLORATION STRATEGY ************
-                             * 0 ... Navigate to nearest frontier TRAVEL PATH
-                             * 1 ... Navigate using auctioning with cluster selection using 
-                             *       NEAREST selection (Kuhn-Munkres)
-                             * 2 ... Navigate to furthest frontier
-                             * 3 ... Navigate to nearest frontier EUCLIDEAN DISTANCE
-                             * 4 ... Navigate to random Frontier
-                             * 5 ... Cluster frontiers, then navigate to nearest cluster 
-                             *       using EUCLIDEAN DISTANCE (with and without
-                             *       negotiation)
-                             * 6 ... Cluster frontiers, then navigate to random cluster
-                             *       (with and without negotiation)
-                             */
-
-                            /******************** SORT *******************
-                            * Choose which strategy to take.
-                            * 1 ... Sort the buffer from furthest to nearest frontier
-                            * 2 ... Sort the buffer from nearest to furthest frontier, normalized to the
-                            *       robots actual position (EUCLIDEAN DISTANCE)
-                            * 3 ... Sort the last 10 entries to shortest TRAVEL PATH
-                            * 4 ... Sort all cluster elements from nearest to furthest (EUCLIDEAN DISTANCE)
-                            */
-                            if(frontier_selection < 0 || frontier_selection > 6)
-                            {
-                                ROS_FATAL("You selected an invalid exploration strategy. Please make sure to set it in the interval [0,6]. The current value is %d.", frontier_selection);
-                            }
-                            if(frontier_selection == 2)
-                            {
-
-                                exploration->sort(1); 
-
-                                /* 
-                                 * Choose which strategy to take.
-                                 * 1 ... least to first goal in list
-                                 * 2 ... first to last goal in list
-                                 *
-                                 * Determine_goal() takes world coordinates stored in
-                                 * the frontiers list(which contain every found frontier with sufficient
-                                 * spacing in between) and returns the most attractive one, based on the
-                                 * above defined strategies.
-                                 */    
-                                while(true)
-                                {   
-                                    goal_determined = exploration->determine_goal(1, &final_goal, count, 0, &robot_str);
-                                    if(goal_determined == false)
-                                    {
-                                        break;
-                                    }
-                                    else
-                                    {   
-                                        //negotiation = exploration->negotiate_Frontier(final_goal.at(0),final_goal.at(1),final_goal.at(2),final_goal.at(3),-1);
-                                        negotiation = true; 
-                                        if(negotiation == true)
-                                        {
-                                            break;
-                                        }
-                                        count++;
-                                    }
-                                }
-                            }    
-                            else if(frontier_selection == 3)
-                            {                           
-                                exploration->sort(2);
-
-                                while(true)
-                                {   
-                                    goal_determined = exploration->determine_goal(2, &final_goal, count, 0, &robot_str);
-                                    if(goal_determined == false)
-                                    {
-                                        break;
-                                    }
-                                    else
-                                    {
-                                        //negotiation = exploration->negotiate_Frontier(final_goal.at(0),final_goal.at(1),final_goal.at(2),final_goal.at(3),-1);
-                                        negotiation = true; 
-                                        if(negotiation == true)
-                                        {
-                                            break;
-                                        }
-                                        count++;
-                                    }
-                                }
-                            }        
-                            else if(frontier_selection == 0)
-                            {
-                                exploration->sort(2);
-                                exploration->sort(3);
-
-                                while(true)
-                                {   
-                                    goal_determined = exploration->determine_goal(2, &final_goal, count, 0, &robot_str);
-                                    ROS_DEBUG("Goal_determined: %d   counter: %d",goal_determined, count);
-                                    if(goal_determined == false)
-                                    {
-                                        break;
-                                    }
-                                    else
-                                    {                        
-                                        //negotiation = exploration->negotiate_Frontier(final_goal.at(0),final_goal.at(1),final_goal.at(2),final_goal.at(3),-1);
-                                        negotiation = true;
-                                        if(negotiation == true)
-                                        {
-                                            break;
-                                        }
-                                        count++;
-                                    }
-                                }
-
-                            }
-                            else if(frontier_selection == 4)
-                            {
-                                while(true)
-                                {   
-                                    goal_determined = exploration->determine_goal(3, &final_goal, count, 0, &robot_str);
-                                    ROS_DEBUG("Goal_determined: %d   counter: %d",goal_determined, count);
-                                    if(goal_determined == false)
-                                    {
-                                        break;
-                                    }
-                                    else
-                                    {
-                                        //negotiation = exploration->negotiate_Frontier(final_goal.at(0),final_goal.at(1),final_goal.at(2),final_goal.at(3),-1);
-                                        negotiation = true; 
-                                        if(negotiation == true)
-                                        {
-                                            break;
-                                        }
-                                        count++;
-                                    }
-                                }
-
-                            }
-                            else if(frontier_selection == 5)
-                            {                            
-                                if(cluster_initialize_flag == true)
-                                {
-                                    exploration->clearVisitedAndSeenFrontiersFromClusters();
-                                }
-                                else
-                                {
-                                    /*
-                                     * This is necessary for the first run 
-                                     */
-                                    if(robot_id == 0)
-                                        ros::Duration(10).sleep();
-
-                                    exploration->sort(2); 
-                                }
-
-                                exploration->clusterFrontiers();                 
-                                exploration->sort(4);      
-                                exploration->sort(5);
-
-    //                            exploration->visualizeClustersConsole();
-
-                                clusters_available_in_pool.clear();
-                                while(true)
-                                {                             
-                                    final_goal.clear();
-                                    goal_determined = exploration->determine_goal(4, &final_goal, count, cluster_element, &robot_str);
-
-                                    if(goal_determined == false)
-                                    {
-                                        ROS_INFO("Another cluster is not available, no cluster determined");                                    
-                                        break;
-                                    }
-                                    else
-                                    {
-                                        if(cluster_initialize_flag == false)
-                                        {
-                                            /*
-                                            *  TODO ... just to reduce the selection of the same 
-                                            * clusters since no auctioning is implemented jet.
-                                            */
-                                           if(robot_id == 1)  
-                                           {
-                                               ros::Duration(5).sleep();
-                                           }
-
-                                           cluster_initialize_flag = true;
-                                        }
-
-                                        /*
-                                         * If negotiation is not needed, simply uncomment
-                                         * and set the negotiation to TRUE.
-                                         */
-                                        negotiation = exploration->negotiate_Frontier(final_goal.at(0),final_goal.at(1),final_goal.at(2),final_goal.at(3),final_goal.at(4));
-//                                        negotiation = true; 
-                                        if(negotiation == true)
-                                        {
-                                            ROS_DEBUG("Negotiation was successful");
-                                            cluster_element = final_goal.at(4);
-                                            counter_waiting_for_clusters = 0;
-                                            break;
-                                        }
-                                        else
-                                        {
-                                            cluster_element = final_goal.at(4);
-                                            counter_waiting_for_clusters++;
-                                            ROS_WARN("Negotiation was not successful, try next cluster");
-                                        }
-                                        count++;
-                                        /*
-                                         * In order to make one robot wait until the other finds
-                                         * another cluster to operate in, one have to fill the clusters_available_in_pool
-                                         * vector if count is increased at least once which determines
-                                         * that at least one cluster
-                                         */
-                                        clusters_available_in_pool.push_back(1);
-                                    }
-                                }
-
-                            } 
-                            else if(frontier_selection == 6)
-                            {                            
-                                if(cluster_initialize_flag == true)
-                                {
-                                    exploration->clearVisitedAndSeenFrontiersFromClusters();
-                                }
-
-                                exploration->clusterFrontiers();   
-                                exploration->sort(6);
-                                exploration->visualizeClustersConsole();
-
-                                if(cluster_initialize_flag == false)
-                                {
-                                    ros::Duration(2).sleep();
-                                }
-                                cluster_initialize_flag = true;
-
-                                while(true)
-                                {             
-                                    goal_determined = exploration->determine_goal(4, &final_goal, count, cluster_element, &robot_str);
-
-                                    if(goal_determined == false)
-                                    {
-                                        break;
-                                    }
-                                    else
-                                    {   
-                                        /*
-                                         * If negotiation is not needed, simply uncomment
-                                         * and set the negotiation to TRUE.
-                                         */
-                                        negotiation = exploration->negotiate_Frontier(final_goal.at(0),final_goal.at(1),final_goal.at(2),final_goal.at(3),final_goal.at(4));
-//                                        negotiation = true; 
-
-                                        if(negotiation == true)
-                                        {
-                                            cluster_element = final_goal.at(4);
-                                            break;
-                                        }
-                                        else
-                                        {
-                                            cluster_element = int(exploration->clusters.size()*rand()/(RAND_MAX));
-                                            ROS_INFO("Random cluster_element: %d  from available %zu clusters", cluster_element, exploration->clusters.size());
-                                        }
-                                        count++;
-                                    }
-                                }
-                            } 
-                            else if(frontier_selection == 1)
-                            {     
-                                costmap_mutex.lock();
-                                if(cluster_initialize_flag == true)
-                                {
-                                     exploration->clearVisitedAndSeenFrontiersFromClusters();
-                                }
-                                else
-                                {                              
-                                    /*
-                                     * This is only necessary for the first run 
-                                     */
-
-                                    exploration->sort(2); 
-                                    cluster_initialize_flag = true;
-                                }
-
-                                exploration->clusterFrontiers();                 
-                                exploration->sort(4);      
-                                exploration->sort(5);
-
-                                costmap_mutex.unlock();
-
-                                exploration->visualizeClustersConsole();
-
-                                while(true)
-                                {                             
-                                    final_goal.clear();
-                                    robot_str.clear();
-                                    goal_determined = exploration->determine_goal(5, &final_goal, 0, cluster_element, &robot_str);
-                                    
-                                    ROS_DEBUG("Cluster element: %d", cluster_element);
-                                    
-                                    int cluster_vector_position = -1;
- 
-                                    if(cluster_element != -1)
-                                    {
-                                        if(exploration->clusters.size() > 0)
-                                        {                   
-                                            for (int i = 0; i < exploration->clusters.size(); i++)
-                                            {
-                                                if(exploration->clusters.at(i).id == cluster_element)
-                                                {
-                                                    if(exploration->clusters.at(i).cluster_element.size() > 0)
-                                                    {
-                                                        cluster_vector_position = i; 
-                                                    }
-                                                    break;
-                                                }
-                                            }
-                                        }
-                                    }
-                                    ROS_DEBUG("Cluster vector position: %d", cluster_vector_position);
-                                    
-                                    if(cluster_vector_position >= 0)
-                                    {
-                                        if(exploration->clusters.at(cluster_vector_position).unreachable_frontier_count >= number_unreachable_frontiers_for_cluster)
-                                        {
-                                            goal_determined = false;
-                                            ROS_WARN("Cluster inoperateable");
-                                        }else
-                                        {
-                                            ROS_WARN("Cluster operateable");
-                                        }
-                                    }
-                                    
-                                    if(goal_determined == false)
-                                    {  
-                                        
-                                        ROS_INFO("No goal was determined, cluster is empty. Bid for another one");
-
-                                        final_goal.clear();
-                                        robot_str.clear();
-                                        clusters_available_in_pool.clear();
-
-                                        bool auctioning = exploration->auctioning(&final_goal, &clusters_available_in_pool, &robot_str);
-                                        if(auctioning == true)
-                                        {
-                                            goal_determined = true; 
-                                            cluster_element = final_goal.at(4);
-                                            counter_waiting_for_clusters = 0;
-                                            break;
-                                        }
-                                        else
-                                        {
-                                            if(exploration->clusters.size() > 0) //clusters_available_in_pool.size() > 0)
-                                            {
-                                                ROS_INFO("No cluster was selected but other robots are operating ... waiting for new clusters");
-                                                counter_waiting_for_clusters++;
-                                                break;
-                                            }else
-                                            {
-                                                /*
-                                                 * If NO goals are selected at all, iterate over the global
-                                                 * map to find some goals. 
-                                                 */
-                                                ROS_WARN("No goals are available at all");
-                                                cluster_element = -1;
-                                                break;
-                                            }
-                                        }
-                                    }
-                                    else
-                                    {
-                                        ROS_INFO("Still some goals in current cluster, finish this job first");
-                                        break;
-                                    }
-                                }
-
-                            } 
-
-
-                             /*
-                             * *****************************************************
-                             * FRONTIER COORDINATION
-                             * *****************************************************
-                             */
-
-
-    //                        exploration->visualize_Clusters();
-                            exploration->visualize_Cluster_Cells();
-                            exploration->visualize_Frontiers();
-    //                        exploration->visualize_visited_Frontiers();
-
-                       
-//                            if (Simulation == false)//cluster_element_size != 0) 
-//                            {
-                                ROS_INFO("Navigating to Goal");
-
-                                if(goal_determined == true)
-                                {
-                                    if(OPERATE_WITH_GOAL_BACKOFF == true)
-                                    {
-                                        ROS_DEBUG("Doing smartGoalBackoff");
-                                        backoff_sucessfull = exploration->smartGoalBackoff(final_goal.at(0),final_goal.at(1), costmap2d_global, &backoffGoal);   
-                                    }
-                                    else
-                                    {
-                                        backoff_sucessfull = true;
-                                    }
-                                }
-
-                                if(backoff_sucessfull == true)
-                                {
-                                    if(OPERATE_WITH_GOAL_BACKOFF == true)
-                                    {
-                                        ROS_INFO("Doing navigation to backoff goal");
-                                        navigate_to_goal = navigate(backoffGoal);
-                                    }else
-                                    {
-                                        ROS_INFO("Doing navigation to goal");
-                                        navigate_to_goal = navigate(final_goal);
-                                    }
-                                }
-                                else if(backoff_sucessfull == false && goal_determined == false)
-                                {
-                                    navigate_to_goal = navigate(final_goal);
-                                    goal_determined = false;
-                                }
-
-
-                                if(navigate_to_goal == true && goal_determined == true)
-                                {
-                                    exploration->calculate_travel_path(exploration->visited_frontiers.at(exploration->visited_frontiers.size()-1).x_coordinate, exploration->visited_frontiers.at(exploration->visited_frontiers.size()-1).y_coordinate);
-
-                                    ROS_DEBUG("Storeing visited...");
-                                    exploration->storeVisitedFrontier(final_goal.at(0),final_goal.at(1),final_goal.at(2),robot_str.at(0),final_goal.at(3)); 
-                                    ROS_DEBUG("Stored Visited frontier");
-                                   
-                                }   
-                                else if(navigate_to_goal == false && goal_determined == true)
-                                {
-                                    ROS_DEBUG("Storeing unreachable...");
-                                    exploration->storeUnreachableFrontier(final_goal.at(0),final_goal.at(1),final_goal.at(2),robot_str.at(0),final_goal.at(3));                            
-                                    ROS_DEBUG("Stored unreachable frontier");
-                                } 
-
-    //                            exploration->clearVisitedFrontiers();
-    //                            exploration->clearUnreachableFrontiers();  
-
-    //                            exploration->publish_frontier_list();  
-    //                            exploration->publish_visited_frontier_list();                           
-//                            }
+                        if (robot_id == 0)
+                        {
+                            ros::Duration(10).sleep();
                         }
-			else
-			{
-				ROS_WARN("No navigation performed");				
-			}		
-			ROS_DEBUG("                                             ");
-                        ROS_DEBUG("                                             ");
-		}
-	}         
-           
+                        exploration->sort(2);
+                    }
+
+                    exploration->clusterFrontiers();
+                    exploration->sort(4);
+                    exploration->sort(5);
+
+                    // exploration->visualizeClustersConsole();
+
+                    clusters_available_in_pool.clear();
+                    while (true)
+                    {
+                        final_goal.clear();
+                        goal_determined = exploration->determine_goal(4, &final_goal, count, cluster_element, &robot_str);
+
+                        if (goal_determined == false)
+                        {
+                            ROS_INFO("Another cluster is not available, no cluster determined");
+                            break;
+                        }
+                        else
+                        {
+                            if (cluster_initialize_flag == false)
+                            {
+                                /*
+                                 *  TODO ... just to reduce the selection of the same
+                                 * clusters since no auctioning is implemented jet.
+                                 */
+                                if (robot_id == 1)
+                                {
+                                    ros::Duration(5).sleep();
+                                }
+
+                                cluster_initialize_flag = true;
+                            }
+
+                            /*
+                             * If negotiation is not needed, simply uncomment
+                             * and set the negotiation to TRUE.
+                             */
+                            negotiation = exploration->negotiate_Frontier(final_goal.at(0),
+                                                                          final_goal.at(1),
+                                                                          final_goal.at(2),
+                                                                          final_goal.at(3),
+                                                                          final_goal.at(4));
+                            if (negotiation == true)
+                            {
+                                ROS_DEBUG("Negotiation was successful");
+                                cluster_element = final_goal.at(4);
+                                counter_waiting_for_clusters = 0;
+                                break;
+                            }
+                            else
+                            {
+                                cluster_element = final_goal.at(4);
+                                counter_waiting_for_clusters++;
+                                ROS_WARN("Negotiation was not successful, try next cluster");
+                            }
+                            count++;
+                            /*
+                             * In order to make one robot wait until the other finds
+                             * another cluster to operate in, one have to fill the clusters_available_in_pool
+                             * vector if count is increased at least once which determines
+                             * that at least one cluster
+                             */
+                            clusters_available_in_pool.push_back(1);
+                        }
+                    }
+                }
+                else if (frontier_selection == 6)
+                {
+                    if (cluster_initialize_flag == true)
+                    {
+                        exploration->clearVisitedAndSeenFrontiersFromClusters();
+                    }
+                    exploration->clusterFrontiers();
+                    exploration->sort(6);
+                    exploration->visualizeClustersConsole();
+
+                    if (cluster_initialize_flag == false)
+                    {
+                        ros::Duration(2).sleep();
+                    }
+                    cluster_initialize_flag = true;
+
+                    while (true)
+                    {
+                        goal_determined = exploration->determine_goal(4, &final_goal, count, cluster_element, &robot_str);
+
+                        if (goal_determined == false)
+                        {
+                            break;
+                        }
+                        else
+                        {
+                            /*
+                             * If negotiation is not needed, simply uncomment
+                             * and set the negotiation to TRUE.
+                             */
+                            negotiation = exploration->negotiate_Frontier(final_goal.at(0),
+                                                                          final_goal.at(1),
+                                                                          final_goal.at(2),
+                                                                          final_goal.at(3),
+                                                                          final_goal.at(4));
+                            // negotiation = true;
+
+                            if (negotiation == true)
+                            {
+                                cluster_element = final_goal.at(4);
+                                break;
+                            }
+                            else
+                            {
+                                cluster_element = int(exploration->clusters.size()*rand()/(RAND_MAX));
+                                ROS_INFO("Random cluster_element: %d  from available %zu clusters", cluster_element, exploration->clusters.size());
+                            }
+                            count++;
+                        }
+                    }
+                }
+                else if (frontier_selection == 1)
+                {
+                    costmap_mutex.lock();
+                    if (cluster_initialize_flag == true)
+                    {
+                        exploration->clearVisitedAndSeenFrontiersFromClusters();
+                    }
+                    else
+                    {
+                        /*
+                         * This is only necessary for the first run
+                         */
+                        exploration->sort(2);
+                        cluster_initialize_flag = true;
+                    }
+
+                    exploration->clusterFrontiers();
+                    exploration->sort(4);
+                    exploration->sort(5);
+
+                    costmap_mutex.unlock();
+
+                    exploration->visualizeClustersConsole();
+
+                    while (true)
+                    {
+                        final_goal.clear();
+                        robot_str.clear();
+                        goal_determined = exploration->determine_goal(5, &final_goal, 0, cluster_element, &robot_str);
+
+                        ROS_DEBUG("Cluster element: %d", cluster_element);
+
+                        int cluster_vector_position = -1;
+
+                        if (cluster_element != -1)
+                        {
+                            if (exploration->clusters.size() > 0)
+                            {
+                                for (int i = 0; i < exploration->clusters.size(); i++)
+                                {
+                                    if (exploration->clusters.at(i).id == cluster_element)
+                                    {
+                                        if (exploration->clusters.at(i).cluster_element.size() > 0)
+                                        {
+                                            cluster_vector_position = i;
+                                        }
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        ROS_DEBUG("Cluster vector position: %d", cluster_vector_position);
+
+                        if (cluster_vector_position >= 0)
+                        {
+                            if (exploration->clusters.at(cluster_vector_position).unreachable_frontier_count >= number_unreachable_frontiers_for_cluster)
+                            {
+                                goal_determined = false;
+                                ROS_WARN("Cluster inoperateable");
+                            }
+                            else
+                            {
+                                ROS_WARN("Cluster operateable");
+                            }
+                        }
+
+                        if (goal_determined == false)
+                        {
+
+                            ROS_INFO("No goal was determined, cluster is empty. Bid for another one");
+
+                            final_goal.clear();
+                            robot_str.clear();
+                            clusters_available_in_pool.clear();
+
+                            bool auctioning = exploration->auctioning(&final_goal, &clusters_available_in_pool, &robot_str);
+                            if (auctioning == true)
+                            {
+                                goal_determined = true;
+                                cluster_element = final_goal.at(4);
+                                counter_waiting_for_clusters = 0;
+                                break;
+                            }
+                            else
+                            {
+                                if (exploration->clusters.size() > 0) //clusters_available_in_pool.size() > 0)
+                                {
+                                    ROS_INFO("No cluster was selected but other robots are operating ... waiting for new clusters");
+                                    counter_waiting_for_clusters++;
+                                    break;
+                                }
+                                else
+                                {
+                                    /*
+                                     * If NO goals are selected at all, iterate over the global
+                                     * map to find some goals.
+                                     */
+                                    ROS_WARN("No goals are available at all");
+                                    cluster_element = -1;
+                                    break;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            ROS_INFO("Still some goals in current cluster, finish this job first");
+                            break;
+                        }
+                    }
+                }
+                /*
+                 * *****************************************************
+                 * FRONTIER COORDINATION
+                 * *****************************************************
+                 */
+                // exploration->visualize_Clusters();
+                exploration->visualize_Cluster_Cells();
+                exploration->visualize_Frontiers();
+                // exploration->visualize_visited_Frontiers();
+
+                // if (Simulation == false)//cluster_element_size != 0)
+                // {
+                ROS_INFO("Navigating to Goal");
+
+                if (goal_determined == true)
+                {
+                    if (OPERATE_WITH_GOAL_BACKOFF == true)
+                    {
+                        ROS_DEBUG("Doing smartGoalBackoff");
+                        backoff_sucessfull = exploration->smartGoalBackoff(final_goal.at(0),final_goal.at(1), costmap2d_global, &backoffGoal);
+                    }
+                    else
+                    {
+                        backoff_sucessfull = true;
+                    }
+                }
+                if (backoff_sucessfull == true)
+                {
+                    if (OPERATE_WITH_GOAL_BACKOFF == true)
+                    {
+                        ROS_INFO("Doing navigation to backoff goal");
+                        navigate_to_goal = navigate(backoffGoal);
+                    }
+                    else
+                    {
+                        ROS_INFO("Doing navigation to goal");
+                        navigate_to_goal = navigate(final_goal);
+                    }
+                }
+                else if (backoff_sucessfull == false && goal_determined == false)
+                {
+                    navigate_to_goal = navigate(final_goal);
+                    goal_determined = false;
+                }
+                if (navigate_to_goal == true && goal_determined == true)
+                {
+                    exploration->calculate_travel_path(exploration->visited_frontiers.at(exploration->visited_frontiers.size()-1).x_coordinate,
+                                                       exploration->visited_frontiers.at(exploration->visited_frontiers.size()-1).y_coordinate);
+
+                    ROS_DEBUG("Storeing visited...");
+                    exploration->storeVisitedFrontier(final_goal.at(0),
+                                                      final_goal.at(1),
+                                                      final_goal.at(2),
+                                                      robot_str.at(0),
+                                                      final_goal.at(3));
+                    ROS_DEBUG("Stored Visited frontier");
+                }
+                else if (navigate_to_goal == false && goal_determined == true)
+                {
+                    ROS_DEBUG("Storeing unreachable...");
+                    exploration->storeUnreachableFrontier(final_goal.at(0),
+                                                          final_goal.at(1),
+                                                          final_goal.at(2),
+                                                          robot_str.at(0),
+                                                          final_goal.at(3));
+                    ROS_DEBUG("Stored unreachable frontier");
+                }
+
+                // exploration->clearVisitedFrontiers();
+                // exploration->clearUnreachableFrontiers();
+
+                // exploration->publish_frontier_list();
+                // exploration->publish_visited_frontier_list();
+                // }
+            }
+            else
+            {
+                ROS_WARN("No navigation performed");
+            }
+            ROS_DEBUG("                                             ");
+            ROS_DEBUG("                                             ");
+        }
+    }
+
         void frontiers()
         {
             ros::Rate r(5);
@@ -911,37 +912,43 @@ public:
             }
         }
         
-        void initLogPath()
+    void initLogPath()
+    {
+        /*
+         *  CREATE LOG PATH
+         * Following code enables to write the output to a file
+         * which is localized at the log_path
+         */
+
+        nh.param<std::string>("log_path", log_path, "");
+
+        std::stringstream robot_number;
+        robot_number << robot_id;
+        std::string prefix = "/robot_";
+        std::string robo_name = prefix.append(robot_number.str());
+
+        log_path = log_path.append("/explorer");
+        log_path = log_path.append(robo_name);
+        log_path = log_path.append("/");
+        ROS_INFO("Logging files to %s", log_path.c_str());
+
+        boost::filesystem::path boost_log_path(log_path.c_str());
+
+        if (!boost::filesystem::exists(boost_log_path))
         {
-           /*
-            *  CREATE LOG PATH
-            * Following code enables to write the output to a file
-            * which is localized at the log_path
-            */
-            
-            nh.param<std::string>("log_path",log_path,"");           
-
-            std::stringstream robot_number;
-            robot_number << robot_id;
-            std::string prefix = "/robot_";
-            std::string robo_name = prefix.append(robot_number.str());    
-
-            log_path = log_path.append("/explorer");
-            log_path = log_path.append(robo_name);
-            log_path = log_path.append("/");
-            ROS_INFO("Logging files to %s", log_path.c_str());
-
-            boost::filesystem::path boost_log_path(log_path.c_str());
-            if(!boost::filesystem::exists(boost_log_path))
-                if(!boost::filesystem::create_directories(boost_log_path))
-                    // directory not created; check if it is there anyways
-                    if(!boost::filesystem::is_directory(boost_log_path))
-                        ROS_ERROR("Cannot create directory %s.", log_path.c_str());
-                    else
-                        ROS_INFO("Successfully created directory %s.", log_path.c_str());
-             
+            boost::filesystem::create_directories(boost_log_path);
+            if (!boost::filesystem::is_directory(boost_log_path))
+            {
+                ROS_ERROR("Cannot create directory %s.", log_path.c_str());
+            }
+            else
+            {
+                ROS_INFO("Successfully created directory %s.", log_path.c_str());
+            }
         }
-        
+        // directory not created; check if it is there anyways
+    }
+
         void save_progress(bool final=false)
         {
             ros::Duration ros_time = ros::Time::now() - time_start;

--- a/map_merger/CMakeLists.txt
+++ b/map_merger/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" )
+if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  # ros-jade-navigation contains funtion that, despite its declaration,
+  # doesn't return anything. Clang will warn us about this which, due to
+  # -Werror flag, will ruin compilation.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+endif()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 project(map_merger)
 ## Find catkin macros and libraries

--- a/map_merger/src/mapmerger.cpp
+++ b/map_merger/src/mapmerger.cpp
@@ -774,7 +774,7 @@ void MapMerger::callback_got_position_network(const adhoc_communication::MmRobot
                 ROS_DEBUG("find trans");
                 int index_transform = findTransformIndex(i);
                 ROS_DEBUG("finished find trans");
-                if(transforms->size() == 0 );
+                if(transforms->size() == 0 )
                 {
                     ROS_WARN("no transformation for %s, position is not published,index:%u, size:%zu",name.c_str(),index_transform,transforms->size());
                 }
@@ -822,8 +822,8 @@ void MapMerger::callback_got_position_network(const adhoc_communication::MmRobot
                 inPts.push_back(org_point);
                 outPts.push_back(homogeneous);
                 cv::Size s;
-                s.height = map_height; //* 0.05;
-                s.width = map_width ;//* 0.05;
+                s.height = map_height; // 0.05;
+                s.width = map_width ;// 0.05;
                 cv::transform(inPts,outPts,trans);
                 tmp.pose.position.x = (outPts.at(0).x - map_width / 2) * 0.05;
                 tmp.pose.position.y = (outPts.at(0).y - map_height / 2) * 0.05;
@@ -1237,16 +1237,24 @@ cv::Mat MapMerger::mapToMat(const nav_msgs::OccupancyGrid *map)
 nav_msgs::OccupancyGrid* MapMerger::matToMap(const Mat mat, nav_msgs::OccupancyGrid *forInfo)
 {
     nav_msgs::OccupancyGrid* toReturn = forInfo;
-    for(size_t i=2; i<toReturn->info.height * toReturn->info.width;i++)
+    for(size_t i=2; i < toReturn->info.height*toReturn->info.width; i++)
     {
-        //toReturn->data.push_back(mat.data[i]);
-       if(mat.data[i]== 254)//KNOWN
-           toReturn->data[i]=0;
+        // toReturn->data.push_back(mat.data[i]);
+        if(mat.data[i]== 254)//KNOWN
+        {
+            toReturn->data[i]=0;
+        }
         // here it is <10 and not 0 (like in mapToMat), becouse otherwise we loose much
-        //walls etc. but so we get a little of wrong information in the unkown area, what is
+        // walls etc. but so we get a little of wrong information in the unkown area, what is
         // not so terrible.
-        else if(mat.data[i] > -1 && mat.data[i] < 50) toReturn->data[i]=100; //WALL
-       else toReturn->data[i] = -1; //UNKOWN
+        else if(mat.data[i] < 50)
+        {
+            toReturn->data[i]=100; //WALL
+        }
+        else
+        {
+            toReturn->data[i] = -1; //UNKOWN
+        }
     }
     return toReturn;
 }
@@ -1683,13 +1691,17 @@ int MapMerger::findTransformIndex(int robot_index)
    // ROS_DEBUG("Could not found TransformIndex for robot_index:%i",robot_index);
     return -1;
 }
-    int MapMerger::findRobotIndex(int transform_index)
+
+int MapMerger::findRobotIndex(int transform_index)
 {
-    for(int i = 0; i < robots_in_transform->size(); i++)
+    for (int i = 0; i < robots_in_transform->size(); i++)
     {
-        if(robots_in_transform->at(transform_index) == robots->at(i))
+        if (robots_in_transform->at(transform_index) == robots->at(i))
+        {
             return i;
+        }
     }
+    return -1;
 }
 
 

--- a/scripts/ros_multi_robot_ready.sh
+++ b/scripts/ros_multi_robot_ready.sh
@@ -1,0 +1,47 @@
+#Add repo to list
+if [ ! -e /etc/apt/sources.list.d/ros-latest.list ]; then
+    sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+fi
+#Add key and update package list
+sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-key 0xB01FA116
+sudo apt-get update -q -y
+
+#fix deps and install ros
+sudo apt-get install -q -y libgl1-mesa-dev-lts-utopic
+sudo apt-get install -q -y ros-jade-desktop-full
+
+#init ros
+sudo rosdep init
+rosdep update
+echo ". /opt/ros/jade/setup.bash" >> ~/.bashrc
+. /opt/ros/jade/setup.bash
+
+#install Git to get packages later
+sudo apt-get install -q -y git
+
+#install available prebuilt packages
+sudo apt-get install -q -y ros-jade-navigation ros-jade-gmapping
+
+#create empty workspace
+mkdir -p ~/catkin_ws/src
+cd ~/catkin_ws/src
+catkin_init_workspace
+cd ~/catkin_ws/src
+
+#get needed packages
+git clone https://github.com/OSLL/aau_multi_robot.git
+git clone https://github.com/LeoSko/teleop_twist_keyboard.git
+
+cd ~/catkin_ws/
+catkin_make
+
+#source environment
+echo ". ~/catkin_ws/devel/setup.bash" >> ~/.bashrc
+. ~/catkin_ws/devel/setup.bash
+
+#configure adhoc_communication package to be run as root by default
+sudo chown root ~/catkin_ws/devel/lib/adhoc_communication/adhoc_communication
+sudo chmod +s ~/catkin_ws/devel/lib/adhoc_communication/adhoc_communication
+
+echo "We are launching exploration for one robot as an example."
+xterm -e roslaunch explorer explore_one.launch


### PR DESCRIPTION
First things first, I think we should have a little install guide that will describe packages that  are needed in order to compile/run this project. I added a little installation guide to `README.rm`.

Now for the sad part. After I typed `catkin_make` in terminal, I saw this:

``` sh
alnen@ubuntu:~/catkin_ws$ catkin_make
Base path: /home/alnen/catkin_ws
Source space: /home/alnen/catkin_ws/src
Build space: /home/alnen/catkin_ws/build
Devel space: /home/alnen/catkin_ws/devel
Install space: /home/alnen/catkin_ws/install
####
#### Running command: "make cmake_check_build_system" in "/home/alnen/catkin_ws/build"
####
-- Using CATKIN_DEVEL_PREFIX: /home/alnen/catkin_ws/devel
-- Using CMAKE_PREFIX_PATH: /home/alnen/catkin_ws/devel;/opt/ros/jade
-- This workspace overlays: /home/alnen/catkin_ws/devel;/opt/ros/jade
-- Using PYTHON_EXECUTABLE: /usr/bin/python
-- Using Debian Python package layout
-- Using empy: /usr/bin/empy
-- Using CATKIN_ENABLE_TESTING: ON
-- Call enable_testing()
-- Using CATKIN_TEST_RESULTS_DIR: /home/alnen/catkin_ws/build/test_results
-- Found gtest sources under '/usr/src/gtest': gtests will be built
-- Using Python nosetests: /usr/bin/nosetests-2.7
-- catkin 0.6.16
-- BUILD_SHARED_LIBS is on
-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- ~~  traversing 4 packages in topological order:
-- ~~  - teleop_twist_keyboard
-- ~~  - adhoc_communication
-- ~~  - map_merger
-- ~~  - explorer
-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- +++ processing catkin package: 'teleop_twist_keyboard'
-- ==> add_subdirectory(teleop_twist_keyboard)
-- +++ processing catkin package: 'adhoc_communication'
-- ==> add_subdirectory(multibot/adhoc_communication)
-- Using these message generators: gencpp;geneus;genlisp;genpy
-- adhoc_communication: 14 messages, 18 services
-- +++ processing catkin package: 'map_merger'
-- ==> add_subdirectory(multibot/map_merger)
-- Using these message generators: gencpp;geneus;genlisp;genpy
-- map_merger: 0 messages, 2 services
-- +++ processing catkin package: 'explorer'
-- ==> add_subdirectory(multibot/explorer)
-- Using these message generators: gencpp;geneus;genlisp;genpy
-- Configuring done
CMake Warning (dev) at multibot/explorer/CMakeLists.txt:140 (add_dependencies):
  Policy CMP0046 is not set: Error on non-existent dependency in
  add_dependencies.  Run "cmake --help-policy CMP0046" for policy details.
  Use the cmake_policy command to set the policy and suppress this warning.

  The dependency target "explorer_generate_messages_cpp" of target "explorer"
  does not exist.
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Generating done
-- Build files have been written to: /home/alnen/catkin_ws/build
####
#### Running command: "make -j8 -l8" in "/home/alnen/catkin_ws/build"
####
[  0%] [  0%] [  0%] Built target nav_msgs_generate_messages_cpp
Built target geometry_msgs_generate_messages_cpp
Built target std_msgs_generate_messages_cpp
[  0%] [  0%] Built target _adhoc_communication_generate_messages_check_deps_GetGroupState
[  0%] Built target _adhoc_communication_generate_messages_check_deps_SendMmRobotPosition
[  0%] Built target _adhoc_communication_generate_messages_check_deps_SendMmMapUpdate
Built target _adhoc_communication_generate_messages_check_deps_SendCMgrRobotUpdate
[  0%] Built target _adhoc_communication_generate_messages_check_deps_SendExpCluster
[  0%] Built target _adhoc_communication_generate_messages_check_deps_SendString
[  0%] Built target _adhoc_communication_generate_messages_check_deps_MmListOfPoints
[  0%] Built target _adhoc_communication_generate_messages_check_deps_MmPoint
[  0%] [  0%] [  0%] Built target _adhoc_communication_generate_messages_check_deps_MmControl
Built target _adhoc_communication_generate_messages_check_deps_SendExpFrontier
Built target _adhoc_communication_generate_messages_check_deps_RecvString
[  0%] Built target _adhoc_communication_generate_messages_check_deps_ExpAuction
[  0%] Built target _adhoc_communication_generate_messages_check_deps_SendOccupancyGrid
[  0%] Built target _adhoc_communication_generate_messages_check_deps_SendTwist
[  0%] [  0%] Built target _adhoc_communication_generate_messages_check_deps_ShutDown
Built target _adhoc_communication_generate_messages_check_deps_SendQuaternion
[  0%] [  0%] Built target _adhoc_communication_generate_messages_check_deps_ExpFrontier
Built target _adhoc_communication_generate_messages_check_deps_MmMapUpdate
[  0%] [  0%] Built target _adhoc_communication_generate_messages_check_deps_BroadcastCMgrRobotUpdate
Built target _adhoc_communication_generate_messages_check_deps_ExpClusterElement
[  0%] Built target _adhoc_communication_generate_messages_check_deps_ExpCluster
[  0%] Built target _adhoc_communication_generate_messages_check_deps_CMgrRobotUpdate
[  0%] [  0%] Built target _adhoc_communication_generate_messages_check_deps_GetNeighbors
Built target _adhoc_communication_generate_messages_check_deps_SendExpAuction
[  0%] Built target _adhoc_communication_generate_messages_check_deps_CMgrDimensions
[  0%] Built target _adhoc_communication_generate_messages_check_deps_MmRobotPosition
[  0%] Built target _adhoc_communication_generate_messages_check_deps_ChangeMCMembership
[  0%] Built target nav_msgs_generate_messages_lisp
[  0%] Built target _adhoc_communication_generate_messages_check_deps_ExpAuctionElement
[  0%] Built target _adhoc_communication_generate_messages_check_deps_SendMmControl
[  0%] Built target _adhoc_communication_generate_messages_check_deps_SendMmPoint
[  0%] [  0%] Built target std_msgs_generate_messages_lisp
Built target geometry_msgs_generate_messages_lisp
[  0%] [  0%] [  0%] Built target _adhoc_communication_generate_messages_check_deps_BroadcastString
Built target geometry_msgs_generate_messages_py
Built target _adhoc_communication_generate_messages_check_deps_ExpFrontierElement
[  0%] [  0%] Built target std_msgs_generate_messages_py
Built target nav_msgs_generate_messages_py
[  0%] Built target geometry_msgs_generate_messages_eus
[  0%] Built target nav_msgs_generate_messages_eus
[  0%] Built target std_msgs_generate_messages_eus
[  1%] [  2%] Building CXX object multibot/explorer/CMakeFiles/hungarian.dir/src/hungarian.cpp.o
[ 23%] Built target adhoc_communication_generate_messages_lisp
[ 44%] Building CXX object multibot/explorer/CMakeFiles/munkres.dir/src/src/munkres.cpp.o
[ 66%] Built target adhoc_communication_generate_messages_cpp
Built target adhoc_communication_generate_messages_eus
[ 88%] [ 88%] Built target adhoc_communication_generate_messages_py
Built target _map_merger_generate_messages_check_deps_LogMaps
[ 88%] [ 88%] Built target _map_merger_generate_messages_check_deps_TransformPoint
Built target adhoc_communication_gencpp
[ 88%] Built target adhoc_communication_generate_messages
[ 91%] [ 91%] [ 93%] Built target map_merger_generate_messages_eus
Built target map_merger_generate_messages_cpp
[ 95%] Built target map_merger_generate_messages_lisp
Built target map_merger_generate_messages_py
[ 95%] Building CXX object multibot/adhoc_communication/CMakeFiles/adhoc_communication.dir/src/adhoc_communication.cpp.o
[ 95%] [ 95%] Built target map_merger_gencpp
Built target map_merger_generate_messages
Scanning dependencies of target map_merger
[ 95%] [ 96%] [ 97%] [ 98%] [ 98%] Building CXX object multibot/map_merger/CMakeFiles/map_merger.dir/src/main.cpp.o
Building CXX object multibot/map_merger/CMakeFiles/map_merger.dir/src/mapstitch.cpp.o
Building CXX object multibot/map_merger/CMakeFiles/map_merger.dir/src/mapmerger.cpp.o
Building CXX object multibot/map_merger/CMakeFiles/map_merger.dir/src/updateentry.cpp.o
Building CXX object multibot/map_merger/CMakeFiles/map_merger.dir/src/updatemanager.cpp.o
Linking CXX shared library /home/alnen/catkin_ws/devel/lib/libmunkres.so
Linking CXX shared library /home/alnen/catkin_ws/devel/lib/libhungarian.so
[ 98%] Built target munkres
[ 98%] Built target hungarian
[ 98%] Building CXX object multibot/explorer/CMakeFiles/exploration_planner.dir/src/ExplorationPlanner.cpp.o
/home/alnen/catkin_ws/src/multibot/map_merger/src/mapmerger.cpp:777:45: error: if statement has empty body [-Werror,-Wempty-body]
                if(transforms->size() == 0 );
                                            ^
/home/alnen/catkin_ws/src/multibot/map_merger/src/mapmerger.cpp:777:45: note: put the semicolon on a separate line to silence this warning
/home/alnen/catkin_ws/src/multibot/map_merger/src/mapmerger.cpp:825:41: error: '/*' within block comment [-Werror,-Wcomment]
                s.height = map_height; //* 0.05;
                                        ^
/home/alnen/catkin_ws/src/multibot/map_merger/src/mapmerger.cpp:826:39: error: '/*' within block comment [-Werror,-Wcomment]
                s.width = map_width ;//* 0.05;
                                      ^
/home/alnen/catkin_ws/src/multibot/map_merger/src/mapmerger.cpp:1248:29: error: comparison of constant -1 with expression of type 'uchar' (aka 'unsigned char') is always true
      [-Werror,-Wtautological-constant-out-of-range-compare]
        else if(mat.data[i] > -1 && mat.data[i] < 50) toReturn->data[i]=100; //WALL
                ~~~~~~~~~~~ ^ ~~
/home/alnen/catkin_ws/src/multibot/map_merger/src/mapmerger.cpp:1693:1: error: control may reach end of non-void function [-Werror,-Wreturn-type]
}
^
In file included from /home/alnen/catkin_ws/src/multibot/adhoc_communication/src/adhoc_communication.cpp:51:
In file included from /home/alnen/catkin_ws/src/multibot/adhoc_communication/src/header.h:78:
/home/alnen/catkin_ws/src/multibot/adhoc_communication/src/functions.h:159:5: error: '/*' within block comment [-Werror,-Wcomment]
    /* Description:
    ^
In file included from /home/alnen/catkin_ws/src/multibot/adhoc_communication/src/adhoc_communication.cpp:51:
In file included from /home/alnen/catkin_ws/src/multibot/adhoc_communication/src/header.h:115:
In file included from /home/alnen/catkin_ws/src/multibot/adhoc_communication/src/McHandler.h:12:
In file included from /home/alnen/catkin_ws/src/multibot/adhoc_communication/src/McTree.cpp:18:
/home/alnen/catkin_ws/src/multibot/adhoc_communication/src/Logging.h:118:1: error: '/*' within block comment [-Werror,-Wcomment]
/* unicast received sent 
^
/home/alnen/catkin_ws/src/multibot/adhoc_communication/src/Logging.h:136:1: error: '/*' within block comment [-Werror,-Wcomment]
/* mc frames sent 
^
/home/alnen/catkin_ws/src/multibot/adhoc_communication/src/Logging.h:151:1: error: '/*' within block comment [-Werror,-Wcomment]
/* mc frames sent 
^
In file included from /home/alnen/catkin_ws/src/multibot/adhoc_communication/src/adhoc_communication.cpp:51:
In file included from /home/alnen/catkin_ws/src/multibot/adhoc_communication/src/header.h:116:
/home/alnen/catkin_ws/src/multibot/adhoc_communication/src/McHandler.cpp:104:1: error: control may reach end of non-void function [-Werror,-Wreturn-type]
}
^
In file included from /home/alnen/catkin_ws/src/multibot/adhoc_communication/src/adhoc_communication.cpp:51:
/home/alnen/catkin_ws/src/multibot/adhoc_communication/src/header.h:835:1: error: control may reach end of non-void function [-Werror,-Wreturn-type]
}
^
/home/alnen/catkin_ws/src/multibot/adhoc_communication/src/header.h:1169:7: error: '/*' within block comment [-Werror,-Wcomment]
      /*
      ^
/home/alnen/catkin_ws/src/multibot/adhoc_communication/src/adhoc_communication.cpp:83:1: error: control may reach end of non-void function [-Werror,-Wreturn-type]
}
^
5 errors generated.
multibot/map_merger/CMakeFiles/map_merger.dir/build.make:77: recipe for target 'multibot/map_merger/CMakeFiles/map_merger.dir/src/mapmerger.cpp.o' failed
make[2]: *** [multibot/map_merger/CMakeFiles/map_merger.dir/src/mapmerger.cpp.o] Error 1
CMakeFiles/Makefile2:2734: recipe for target 'multibot/map_merger/CMakeFiles/map_merger.dir/all' failed
make[1]: *** [multibot/map_merger/CMakeFiles/map_merger.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
8 errors generated.
multibot/adhoc_communication/CMakeFiles/adhoc_communication.dir/build.make:54: recipe for target 'multibot/adhoc_communication/CMakeFiles/adhoc_communication.dir/src/adhoc_communication.cpp.o' failed
make[2]: *** [multibot/adhoc_communication/CMakeFiles/adhoc_communication.dir/src/adhoc_communication.cpp.o] Error 1
CMakeFiles/Makefile2:1567: recipe for target 'multibot/adhoc_communication/CMakeFiles/adhoc_communication.dir/all' failed
make[1]: *** [multibot/adhoc_communication/CMakeFiles/adhoc_communication.dir/all] Error 2
In file included from /home/alnen/catkin_ws/src/multibot/explorer/src/ExplorationPlanner.cpp:1:
In file included from /home/alnen/catkin_ws/src/multibot/explorer/include/ExplorationPlanner.h:5:
In file included from /opt/ros/jade/include/navfn/navfn_ros.h:48:
/opt/ros/jade/include/nav_core/base_global_planner.h:74:7: error: control reaches end of non-void function [-Werror,-Wreturn-type]
      }
      ^
/home/alnen/catkin_ws/src/multibot/explorer/src/ExplorationPlanner.cpp:482:56: error: using integer absolute value function 'abs' when argument is of floating point type [-Werror,-Wabsolute-value]
                                        int x_length = abs(clusters.at(i).cluster_element.at(m).x_coordinate - clusters.at(j).cluster_element.at(n).x_coordinate);
                                                       ^
/home/alnen/catkin_ws/src/multibot/explorer/src/ExplorationPlanner.cpp:482:56: note: use function 'std::abs' instead
                                        int x_length = abs(clusters.at(i).cluster_element.at(m).x_coordinate - clusters.at(j).cluster_element.at(n).x_coordinate);
                                                       ^~~
                                                       std::abs
/home/alnen/catkin_ws/src/multibot/explorer/src/ExplorationPlanner.cpp:483:56: error: using integer absolute value function 'abs' when argument is of floating point type [-Werror,-Wabsolute-value]
                                        int y_length = abs(clusters.at(i).cluster_element.at(m).y_coordinate - clusters.at(j).cluster_element.at(n).y_coordinate);
                                                       ^
/home/alnen/catkin_ws/src/multibot/explorer/src/ExplorationPlanner.cpp:483:56: note: use function 'std::abs' instead
                                        int y_length = abs(clusters.at(i).cluster_element.at(m).y_coordinate - clusters.at(j).cluster_element.at(n).y_coordinate);
                                                       ^~~
                                                       std::abs
/home/alnen/catkin_ws/src/multibot/explorer/src/ExplorationPlanner.cpp:486:58: error: using integer absolute value function 'abs' when argument is of floating point type [-Werror,-Wabsolute-value]
                                        int x_elements = abs(x_length / costmap_resolution);
                                                         ^
/home/alnen/catkin_ws/src/multibot/explorer/src/ExplorationPlanner.cpp:486:58: note: use function 'std::abs' instead
                                        int x_elements = abs(x_length / costmap_resolution);
                                                         ^~~
                                                         std::abs
/home/alnen/catkin_ws/src/multibot/explorer/src/ExplorationPlanner.cpp:487:58: error: using integer absolute value function 'abs' when argument is of floating point type [-Werror,-Wabsolute-value]
                                        int y_elements = abs(y_length / costmap_resolution);
                                                         ^
/home/alnen/catkin_ws/src/multibot/explorer/src/ExplorationPlanner.cpp:487:58: note: use function 'std::abs' instead
                                        int y_elements = abs(y_length / costmap_resolution);
                                                         ^~~
                                                         std::abs
/home/alnen/catkin_ws/src/multibot/explorer/src/ExplorationPlanner.cpp:606:1: error: control reaches end of non-void function [-Werror,-Wreturn-type]
}
^
/home/alnen/catkin_ws/src/multibot/explorer/src/ExplorationPlanner.cpp:747:1: error: control reaches end of non-void function [-Werror,-Wreturn-type]
}
^
/home/alnen/catkin_ws/src/multibot/explorer/src/ExplorationPlanner.cpp:849:1: error: control reaches end of non-void function [-Werror,-Wreturn-type]
}
^
/home/alnen/catkin_ws/src/multibot/explorer/src/ExplorationPlanner.cpp:1479:1: error: control reaches end of non-void function [-Werror,-Wreturn-type]
}
^
/home/alnen/catkin_ws/src/multibot/explorer/src/ExplorationPlanner.cpp:1779:1: error: control reaches end of non-void function [-Werror,-Wreturn-type]
}
^
/home/alnen/catkin_ws/src/multibot/explorer/src/ExplorationPlanner.cpp:2450:1: error: control reaches end of non-void function [-Werror,-Wreturn-type]
}
^
/home/alnen/catkin_ws/src/multibot/explorer/src/ExplorationPlanner.cpp:2478:1: error: control reaches end of non-void function [-Werror,-Wreturn-type]
}
^
/home/alnen/catkin_ws/src/multibot/explorer/src/ExplorationPlanner.cpp:3343:1: error: control reaches end of non-void function [-Werror,-Wreturn-type]
}
^
/home/alnen/catkin_ws/src/multibot/explorer/src/ExplorationPlanner.cpp:4469:1: error: control may reach end of non-void function [-Werror,-Wreturn-type]
}
^
14 errors generated.
multibot/explorer/CMakeFiles/exploration_planner.dir/build.make:54: recipe for target 'multibot/explorer/CMakeFiles/exploration_planner.dir/src/ExplorationPlanner.cpp.o' failed
make[2]: *** [multibot/explorer/CMakeFiles/exploration_planner.dir/src/ExplorationPlanner.cpp.o] Error 1
CMakeFiles/Makefile2:3695: recipe for target 'multibot/explorer/CMakeFiles/exploration_planner.dir/all' failed
make[1]: *** [multibot/explorer/CMakeFiles/exploration_planner.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2
Invoking "make -j8 -l8" failed
alnen@ubuntu:~/catkin_ws$ 
```

It looks like clang found some warnings. Shortly about these warnings:
1) Harmless, easy to fix bug:

``` c++
    if(transforms->size() == 0 );
    {
        ROS_WARN("no transformation for %s, position is not published,index:%u, size:%zu",name.c_str(),index_transform,transforms->size());
    }
```

2) Warning about comparing `uchar` variable with -1.
3) Several warning about implicit conversions in uses of `abs` function.
3) A LOT OF warnings with message:
    `error: control reaches end of non-void function [-Werror,-Wreturn-type]`
The really bad news here is that, this project contains functions that span for more then 400 LOC and don't contain a SINGLE return statement, even though, according to their signature, they must.

Even after fixing all warnings inside this project I am still unable to compile it using clang. It will print out next warning:

``` sh
/opt/ros/jade/include/nav_core/base_global_planner.h:74:7: error: control reaches end of non-void function [-Werror,-Wreturn-type]
      }
      ^
```

I looked at the code and saw this:

``` c++
      /**
       * @brief Given a goal pose in the world, compute a plan
       * @param start The start pose 
       * @param goal The goal pose 
       * @param plan The plan... filled by the planner
       * @param cost The plans calculated cost
       * @return True if a valid plan was found, false otherwise
       */
      virtual bool makePlan(const geometry_msgs::PoseStamped& start, 
                            const geometry_msgs::PoseStamped& goal, std::vector<geometry_msgs::PoseStamped>& plan,
                            double& cost)
      {
        cost = 0;
        makePlan(start, goal, plan);
      }
```

As a temporal solution I decided to disable `-Werror` flag when this project is being compiled using clang as compiler.
