### PR TITLE
Auto-rooting adhoc_communication node

### DIFF
--- a/adhoc_communication/CMakeLists.txt
+++ b/adhoc_communication/CMakeLists.txt
@@ -176,9 +176,9 @@ add_dependencies(adhoc_communication adhoc_communication_gencpp)
 
 add_custom_command(
 TARGET adhoc_communication 
-COMMAND echo "Do not forget to set UID bit and changing owner to root of adhoc_communication node. The node requires root privileges using sudo to have access to the Linux RAW_SOCKET to send data."
-#COMMAND sudo chown root ../../devel/lib/adhoc_communication/adhoc_communication
-#COMMAND sudo chmod +s ../../devel/lib/adhoc_communication/adhoc_communication
+COMMAND echo "Setting UID bit and changing owner to root of adhoc_communication node. The node requires root privileges using sudo to have access to the Linux RAW_SOCKET to send data."
+COMMAND sudo chown root ../../../devel/lib/adhoc_communication/adhoc_communication
+COMMAND sudo chmod +s ../../../devel/lib/adhoc_communication/adhoc_communication
 )
 
 #############


### PR DESCRIPTION
It would be better if someone also tested if it really roots adhoc_communication node. Do it by so:
0. Go catkin workspace
1. Clean up catkin workspace (`rm rf build/ devel/` from catkin workspace dir)
2. `catkin_make`
3. go to `devel/lib/adhoc_communication` and type in `ls -l`, you should see something like
`-rwsrwsr-x 1 root leosko 3996812 марта  2 10:40 adhoc_communication`
